### PR TITLE
Comfirm type req, res when functionBinding is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ you can define your own `function.json` in Typescript object (as you can see the
 import { BaseFunction, Binding, functionName } from 'nammatham';
 
 const bindings = [
-  Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 
 @functionName('GetUser', ...bindings)

--- a/docs/define-azure-function.md
+++ b/docs/define-azure-function.md
@@ -77,8 +77,8 @@ In case your want to define your [function.json](https://learn.microsoft.com/en-
 import { BaseFunction, Binding, functionName } from 'nammatham';
 
 const bindings = [
-  Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 
 @functionName('GetUser', ...bindings)
@@ -121,8 +121,8 @@ For example, if you want to use `customTrigger`, you can simply do like this:
 import { BaseFunction, Binding, functionName } from 'nammatham';
 
 const bindings = [
-  Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 
 // the type should be supported by Azure Functions runtime

--- a/docs/how-it-work.md
+++ b/docs/how-it-work.md
@@ -171,19 +171,19 @@ As you can see the example below:
 
 ```ts
 // nammatham@0.4.0-alpha
-import { BaseController, controller, functionName, GetContextBindings, HttpTriggerRequestBinding, HttpTriggerResponseBinding } from 'nammatham';
+import { BaseController, controller, functionName, GetContextBindings, httpTriggerBinding, HttpBinding } from 'nammatham';
 
 const functionBinding1 = [
   {
     name: 'req',
     type: 'httpTrigger',
     direction: 'in',
-  } as HttpTriggerRequestBinding<'req'>,
+  } as httpTriggerBinding<'req'>,
   {
     name: 'res',
     direction: 'out',
     type: 'http',
-  } as HttpTriggerResponseBinding<'res'>,
+  } as HttpBinding<'res'>,
 ];
 
 const functionBinding2 = [
@@ -191,12 +191,12 @@ const functionBinding2 = [
     name: 'req',
     type: 'httpTrigger',
     direction: 'in',
-  } as HttpTriggerRequestBinding<'req'>,
+  } as httpTriggerBinding<'req'>,
   {
     name: 'res',
     direction: 'out',
     type: 'http',
-  } as HttpTriggerResponseBinding<'res'>,
+  } as HttpBinding<'res'>,
 ];
 
 @controller()
@@ -232,12 +232,12 @@ const functionBinding1 = [
     name: 'req',
     type: 'httpTrigger',
     direction: 'in',
-  } as HttpTriggerRequestBinding<'req'>,
+  } as httpTriggerBinding<'req'>,
   {
     name: 'res',
     direction: 'out',
     type: 'http',
-  } as HttpTriggerResponseBinding<'res'>,
+  } as HttpBinding<'res'>,
 ];
 
 
@@ -260,8 +260,8 @@ Moreover, we can use `Binding` object which a helper to create a function bindin
 import { Binding } from 'nammatham';
 
 const functionBinding1 = [
-  Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 ```
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "serve": "run-s build start",
     "debug": "tsc && npm run start",
-    "build": "cross-env nammatham_env=build ts-node src/startup.ts && tsc",
+    "build": "cross-env nammatham_env=build tsx src/startup.ts && tsc",
     "serve:watch": "nodemon --watch src --ext ts --exec 'npm run serve'",
     "build:watch": "nodemon --watch src --ext ts --delay 0.5 --exec 'npm run build'",
     "start:watch": "nodemon --watch dist --delay 0.3 --exec  'npm start'",
@@ -25,7 +25,6 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "npm-run-all": "^4.1.5",
-    "ts-node": "^10.9.1",
     "tsx": "latest",
     "typescript": "latest"
   }

--- a/examples/basic/src/functions/custom-type.function.ts
+++ b/examples/basic/src/functions/custom-type.function.ts
@@ -1,7 +1,7 @@
 import { BaseFunction, Binding, functionName } from 'nammatham';
 
 const bindings = [
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 
 // the type should be supported by Azure Functions runtime

--- a/examples/basic/src/functions/with-type-utility.controller.ts
+++ b/examples/basic/src/functions/with-type-utility.controller.ts
@@ -9,16 +9,12 @@ const bindings = [
 
 @functionName('WithTypeUtility', ...bindings)
 export class WithTypeUtilityFunction extends BaseFunction<typeof bindings> {
-
-  constructor(@inject(Service) private service: Service){
+  constructor(@inject(Service) private service: Service) {
     super();
   }
-  
+
   public override execute() {
-    const { req, res } = this.context.bindings;
-    const name = req.query.name;
-    this.context.res = {
-      body: `hello WithTypeUtility with ${name} ${this.service.getData()}`,
-    };
+    const { name } = this.req.query;
+    this.res.send(`hello WithTypeUtility with ${name} ${this.service.getData()}`);
   }
 }

--- a/examples/basic/src/functions/with-type-utility.controller.ts
+++ b/examples/basic/src/functions/with-type-utility.controller.ts
@@ -3,8 +3,8 @@ import { BaseFunction, Binding, functionName } from 'nammatham';
 import { Service } from './services';
 
 const bindings = [
-  Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 
 @functionName('WithTypeUtility', ...bindings)

--- a/examples/basic/src/functions/with-type-utility.controller.ts
+++ b/examples/basic/src/functions/with-type-utility.controller.ts
@@ -1,7 +1,6 @@
 import { inject } from 'inversify';
 import { BaseFunction, Binding, functionName } from 'nammatham';
 import { Service } from './services';
-import { HttpResponse } from '@azure/functions';
 
 const bindings = [
   Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,8 +113,8 @@ you can define your own `function.json` in Typescript object (as you can see the
 import { BaseFunction, Binding, functionName } from 'nammatham';
 
 const bindings = [
-  Binding.httpTriggerRequest({ name: 'req' as const }), // make string to literal type
-  Binding.httpTriggerResponse({ name: 'res' as const }), // make string to literal type
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
 ];
 
 @functionName('GetUser', ...bindings)

--- a/packages/core/src/base-function.ts
+++ b/packages/core/src/base-function.ts
@@ -1,18 +1,19 @@
 import { injectable } from 'inversify';
 import { HttpResponse } from '@azure/functions';
 import { HttpResponseContext } from './http';
-import { FunctionBinding } from './bindings';
-import { TypedContext } from './interfaces';
+import { FunctionBinding, HttpTriggerResponseType } from './bindings';
+import { IsBindingWith, TypedContext } from './interfaces';
 
 @injectable()
 export abstract class BaseFunction<T extends readonly FunctionBinding<unknown>[] = any> {
+  
   protected context!: TypedContext<T>;
-  // @injectContext protected readonly context!: Context;
-  protected res!: HttpResponseContext;
+  protected res!: IsBindingWith<T, HttpTriggerResponseType, HttpResponseContext>;
 
   public init(context: TypedContext<T>) {
     this.context = context;
-    this.res = new HttpResponseContext(context);
+    if (context.res !== undefined)
+      this.res = new HttpResponseContext(context) as IsBindingWith<T, HttpTriggerResponseType, HttpResponseContext>;
   }
 
   public abstract execute(...args: any[]): void | HttpResponse;

--- a/packages/core/src/base-function.ts
+++ b/packages/core/src/base-function.ts
@@ -1,19 +1,19 @@
 import { injectable } from 'inversify';
 import { HttpResponse } from '@azure/functions';
 import { HttpResponseContext } from './http';
-import { FunctionBinding, HttpTriggerResponseType } from './bindings';
+import { FunctionBinding, HttpType } from './bindings';
 import { IsBindingWith, TypedContext } from './interfaces';
 
 @injectable()
 export abstract class BaseFunction<T extends readonly FunctionBinding<unknown>[] = any> {
   
   protected context!: TypedContext<T>;
-  protected res!: IsBindingWith<T, HttpTriggerResponseType, HttpResponseContext>;
+  protected res!: IsBindingWith<T, HttpType, HttpResponseContext>;
 
   public init(context: TypedContext<T>) {
     this.context = context;
     if (context.res !== undefined)
-      this.res = new HttpResponseContext(context) as IsBindingWith<T, HttpTriggerResponseType, HttpResponseContext>;
+      this.res = new HttpResponseContext(context) as IsBindingWith<T, HttpType, HttpResponseContext>;
   }
 
   public abstract execute(...args: any[]): void | HttpResponse;

--- a/packages/core/src/base-function.ts
+++ b/packages/core/src/base-function.ts
@@ -1,7 +1,7 @@
 import { injectable } from 'inversify';
-import { HttpResponse } from '@azure/functions';
+import { HttpRequest, HttpResponse } from '@azure/functions';
 import { HttpResponseContext } from './http';
-import { FunctionBinding, HttpType } from './bindings';
+import { FunctionBinding, HttpType, httpTriggerType } from './bindings';
 import { IsBindingWith, TypedContext } from './interfaces';
 
 @injectable()
@@ -9,11 +9,14 @@ export abstract class BaseFunction<T extends readonly FunctionBinding<unknown>[]
   
   protected context!: TypedContext<T>;
   protected res!: IsBindingWith<T, HttpType, HttpResponseContext>;
+  protected req!: IsBindingWith<T, httpTriggerType, HttpRequest>;
 
   public init(context: TypedContext<T>) {
     this.context = context;
     if (context.res !== undefined)
       this.res = new HttpResponseContext(context) as IsBindingWith<T, HttpType, HttpResponseContext>;
+    if(context.req !== undefined)
+      this.req = context.req;
   }
 
   public abstract execute(...args: any[]): void | HttpResponse;

--- a/packages/core/src/bindings/helpers/binding.ts
+++ b/packages/core/src/bindings/helpers/binding.ts
@@ -1,4 +1,4 @@
-import {CustomFunctionBinding, HttpTriggerRequestBinding, HttpTriggerResponseBinding, TimerTriggerBinding } from '../interfaces';
+import {CustomFunctionBinding, httpTriggerBinding, HttpBinding, TimerTriggerBinding } from '../interfaces';
 
 export function custom<T extends CustomFunctionBinding<unknown>>(
   bindings: T
@@ -6,9 +6,9 @@ export function custom<T extends CustomFunctionBinding<unknown>>(
   return bindings;
 }
 
-export function httpTriggerRequest<T extends Omit<HttpTriggerRequestBinding<unknown>, 'type' | 'direction'>>(
+export function httpTrigger<T extends Omit<httpTriggerBinding<unknown>, 'type' | 'direction'>>(
   bindings: T
-): HttpTriggerRequestBinding<T['name']> {
+): httpTriggerBinding<T['name']> {
   return {
     ...bindings,
     type: 'httpTrigger',
@@ -16,9 +16,9 @@ export function httpTriggerRequest<T extends Omit<HttpTriggerRequestBinding<unkn
   };
 }
 
-export function httpTriggerResponse<T extends Omit<HttpTriggerResponseBinding<unknown>, 'type' | 'direction'>>(
+export function http<T extends Omit<HttpBinding<unknown>, 'type' | 'direction'>>(
   bindings: T
-): HttpTriggerResponseBinding<T['name']> {
+): HttpBinding<T['name']> {
   return {
     ...bindings,
     type: 'http',
@@ -37,8 +37,8 @@ export function timeTrigger<T extends Omit<TimerTriggerBinding<unknown>, 'type' 
 }
 
 export default {
-  httpTriggerRequest,
-  httpTriggerResponse,
+  httpTrigger,
+  http,
   timeTrigger,
   custom,
 };

--- a/packages/core/src/bindings/interfaces/function-binding.ts
+++ b/packages/core/src/bindings/interfaces/function-binding.ts
@@ -1,9 +1,9 @@
 import { CustomFunctionBinding } from './custom-function-binding';
-import { HttpTriggerRequestBinding, HttpTriggerResponseBinding, TimerTriggerBinding } from './triggers';
+import { httpTriggerBinding, HttpBinding, TimerTriggerBinding } from './triggers';
 
 export type DefinedFunctionBinding<T extends unknown> =
-  | HttpTriggerRequestBinding<T>
-  | HttpTriggerResponseBinding<T>
+  | httpTriggerBinding<T>
+  | HttpBinding<T>
   | TimerTriggerBinding<T>;
 
 /**

--- a/packages/core/src/bindings/interfaces/triggers/http-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/http-trigger.binding.ts
@@ -6,15 +6,20 @@ export enum AuthorizationLevel {
 }
 
 /**
+ * Azure Functions Http Trigger Request Type
+ */
+export type HttpTriggerRequestType = 'httpTrigger';
+
+/**
  * HttpTrigger Binding
  *
  * read more: [HttpTrigger Configuration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#configuration)
  */
-export interface HttpTriggerRequestBinding<T> extends BaseFunctionBinding<'httpTrigger', T> {
+export interface HttpTriggerRequestBinding<T> extends BaseFunctionBinding<HttpTriggerRequestType, T> {
   /**
    * Required - must be set to `httpTrigger`.
    */
-  type: 'httpTrigger';
+  type: HttpTriggerRequestType;
   /**
    * Required - must be set to in.
    */
@@ -36,7 +41,14 @@ export interface HttpTriggerRequestBinding<T> extends BaseFunctionBinding<'httpT
   route?: string;
 }
 
-export interface HttpTriggerResponseBinding<T> extends BaseFunctionBinding<'http', T> {
-  type: 'http';
+
+/**
+ * Azure Functions Http Response Type
+ */
+export type HttpTriggerResponseType = 'http';
+
+// TODO: rename from HttpTriggerResponseBinding to HttpResponseBinding
+export interface HttpTriggerResponseBinding<T> extends BaseFunctionBinding<HttpTriggerResponseType, T> {
+  type: HttpTriggerResponseType;
   direction: 'out';
 }

--- a/packages/core/src/bindings/interfaces/triggers/http-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/http-trigger.binding.ts
@@ -8,18 +8,18 @@ export enum AuthorizationLevel {
 /**
  * Azure Functions Http Trigger Request Type
  */
-export type HttpTriggerRequestType = 'httpTrigger';
+export type httpTriggerType = 'httpTrigger';
 
 /**
  * HttpTrigger Binding
  *
  * read more: [HttpTrigger Configuration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#configuration)
  */
-export interface HttpTriggerRequestBinding<T> extends BaseFunctionBinding<HttpTriggerRequestType, T> {
+export interface httpTriggerBinding<T> extends BaseFunctionBinding<httpTriggerType, T> {
   /**
    * Required - must be set to `httpTrigger`.
    */
-  type: HttpTriggerRequestType;
+  type: httpTriggerType;
   /**
    * Required - must be set to in.
    */
@@ -45,10 +45,10 @@ export interface HttpTriggerRequestBinding<T> extends BaseFunctionBinding<HttpTr
 /**
  * Azure Functions Http Response Type
  */
-export type HttpTriggerResponseType = 'http';
+export type HttpType = 'http';
 
-// TODO: rename from HttpTriggerResponseBinding to HttpResponseBinding
-export interface HttpTriggerResponseBinding<T> extends BaseFunctionBinding<HttpTriggerResponseType, T> {
-  type: HttpTriggerResponseType;
+// TODO: rename from HttpBinding to HttpResponseBinding
+export interface HttpBinding<T> extends BaseFunctionBinding<HttpType, T> {
+  type: HttpType;
   direction: 'out';
 }

--- a/packages/core/src/bindings/interfaces/triggers/timer-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/timer-trigger.binding.ts
@@ -1,12 +1,17 @@
 import { BaseFunctionBinding } from '../base-function-binding';
 
 /**
+ * Azure Functions Timer Trigger Type
+ */
+export type TimerTriggerType = 'timerTrigger';
+
+/**
  * TimerTrigger Binding
  *
  * read more: [TimerTrigger Configuration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=in-process&pivots=programming-language-javascript#configuration)
  */
-export interface TimerTriggerBinding<T> extends BaseFunctionBinding<'timerTrigger', T> {
-  type: 'timerTrigger';
+export interface TimerTriggerBinding<T> extends BaseFunctionBinding<TimerTriggerType, T> {
+  type: TimerTriggerType;
   /**
    * timerTrigger requires direction `in`
    */

--- a/packages/core/src/bindings/types/binding.ts
+++ b/packages/core/src/bindings/types/binding.ts
@@ -1,4 +1,4 @@
-import { HttpTriggerRequestType, HttpTriggerResponseType, TimerTriggerType } from '../interfaces';
+import { httpTriggerType, HttpType, TimerTriggerType } from '../interfaces';
 import { FunctionBinding } from '../interfaces/function-binding';
 import { HttpRequest, HttpResponse, Timer } from '@azure/functions';
 
@@ -6,13 +6,13 @@ export type AllBindingTypes = FunctionBinding<unknown>['type'];
 /**
  * Only trigger with direction `in`
  */
-export type AllBindingInputTypes = Exclude<AllBindingTypes, HttpTriggerResponseType>;
+export type AllBindingInputTypes = Exclude<AllBindingTypes, HttpType>;
 
-export type BindingType<T extends AllBindingTypes> = T extends HttpTriggerRequestType
+export type BindingType<T extends AllBindingTypes> = T extends httpTriggerType
   ? HttpRequest
   : T extends TimerTriggerType
   ? Timer
-  : T extends HttpTriggerResponseType
+  : T extends HttpType
   ? HttpResponse
   : any;
 

--- a/packages/core/src/bindings/types/binding.ts
+++ b/packages/core/src/bindings/types/binding.ts
@@ -1,3 +1,4 @@
+import { HttpTriggerRequestType, HttpTriggerResponseType, TimerTriggerType } from '../interfaces';
 import { FunctionBinding } from '../interfaces/function-binding';
 import { HttpRequest, HttpResponse, Timer } from '@azure/functions';
 
@@ -5,13 +6,13 @@ export type AllBindingTypes = FunctionBinding<unknown>['type'];
 /**
  * Only trigger with direction `in`
  */
-export type AllBindingInputTypes = Exclude<AllBindingTypes, 'http'>;
+export type AllBindingInputTypes = Exclude<AllBindingTypes, HttpTriggerResponseType>;
 
-export type BindingType<T extends AllBindingTypes> = T extends 'httpTrigger'
+export type BindingType<T extends AllBindingTypes> = T extends HttpTriggerRequestType
   ? HttpRequest
-  : T extends 'timerTrigger'
+  : T extends TimerTriggerType
   ? Timer
-  : T extends 'http'
+  : T extends HttpTriggerResponseType
   ? HttpResponse
   : any;
 

--- a/packages/core/src/bootstrap/function-bootstrap.ts
+++ b/packages/core/src/bootstrap/function-bootstrap.ts
@@ -16,7 +16,7 @@ export function funcBootstrap(option: IFuncBootstrapOption) {
 
   const controllerInstance = container.getNamed<BaseFunction<any>>(TYPE.Controller, option.classTarget.name);
   // Set context to in
-  controllerInstance.init(azureFunctionContext);
+  controllerInstance.init(azureFunctionContext as any);
   // TODO: Move Check to check on build processs
   // if(!(controllerInstance.hasOwnProperty('execute'))){
   //   console.error( `No execute method overrided in the BaseFunction`)

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -5,8 +5,8 @@ import {
   GetContextBindings,
   FunctionBinding,
   BaseFunctionBinding,
-  HttpTriggerResponseType,
-  HttpTriggerRequestType,
+  HttpType,
+  httpTriggerType,
 } from './bindings';
 
 export type GetReturnType<ReturnType, FallbackReturnType> = FallbackReturnType extends undefined
@@ -25,12 +25,12 @@ export interface TypedContext<T extends readonly FunctionBinding<unknown>[]> ext
   /**
    * Add prop from the base interface, based on FunctionBinding
    */
-  res: IsBindingWith<T, HttpTriggerResponseType, HttpResponse, OriginalContextRes>;
+  res: IsBindingWith<T, HttpType, HttpResponse, OriginalContextRes>;
 
   /**
    * Override prop req from the base interface, based on FunctionBinding
    */
-  req: IsBindingWith<T, HttpTriggerRequestType, HttpRequest>;
+  req: IsBindingWith<T, httpTriggerType, HttpRequest>;
 
   /**
    * Provide more specific type from FunctionBinding

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -1,17 +1,31 @@
 // Ref: https://github.com/inversify/inversify-express-utils/blob/master/src/interfaces.ts
 
 import { Context, HttpRequest, HttpResponse } from '@azure/functions';
-import { GetContextBindings, FunctionBinding, BaseFunctionBinding, HttpTriggerResponseType, HttpTriggerRequestType } from './bindings';
+import {
+  GetContextBindings,
+  FunctionBinding,
+  BaseFunctionBinding,
+  HttpTriggerResponseType,
+  HttpTriggerRequestType,
+} from './bindings';
 
-export type IsBindingWith<T extends readonly FunctionBinding<unknown>[], Type, ReturnType> = Type extends T[number]['type']
+export type GetReturnType<ReturnType, FallbackReturnType> = FallbackReturnType extends undefined
   ? ReturnType
-  : ReturnType | undefined;
+  : FallbackReturnType;
+export type IsBindingWith<
+  T extends readonly FunctionBinding<unknown>[],
+  Type,
+  ReturnType,
+  FallbackReturnType = undefined
+> = Type extends T[number]['type'] ? ReturnType : GetReturnType<ReturnType, FallbackReturnType> | undefined;
+
+type OriginalContextRes = NonNullable<Context['res']>;
 
 export interface TypedContext<T extends readonly FunctionBinding<unknown>[]> extends Omit<Context, 'req'> {
   /**
    * Add prop from the base interface, based on FunctionBinding
    */
-  res: IsBindingWith<T, HttpTriggerResponseType, HttpResponse>;
+  res: IsBindingWith<T, HttpTriggerResponseType, HttpResponse, OriginalContextRes>;
 
   /**
    * Override prop req from the base interface, based on FunctionBinding

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -1,13 +1,22 @@
 // Ref: https://github.com/inversify/inversify-express-utils/blob/master/src/interfaces.ts
 
-import { Context, HttpResponse } from '@azure/functions';
-import { GetContextBindings, FunctionBinding, BaseFunctionBinding } from './bindings';
+import { Context, HttpRequest, HttpResponse } from '@azure/functions';
+import { GetContextBindings, FunctionBinding, BaseFunctionBinding, HttpTriggerResponseType, HttpTriggerRequestType } from './bindings';
 
-export interface TypedContext<T extends readonly FunctionBinding<unknown>[]> extends Context {
+export type IsBindingWith<T extends readonly FunctionBinding<unknown>[], Type, ReturnType> = Type extends T[number]['type']
+  ? ReturnType
+  : ReturnType | undefined;
+
+export interface TypedContext<T extends readonly FunctionBinding<unknown>[]> extends Omit<Context, 'req'> {
   /**
-   * Add prop from the base interface
+   * Add prop from the base interface, based on FunctionBinding
    */
-  res?: HttpResponse;
+  res: IsBindingWith<T, HttpTriggerResponseType, HttpResponse>;
+
+  /**
+   * Override prop req from the base interface, based on FunctionBinding
+   */
+  req: IsBindingWith<T, HttpTriggerRequestType, HttpRequest>;
 
   /**
    * Provide more specific type from FunctionBinding


### PR DESCRIPTION
Previously, 

```ts
import { Context, HttpRequest, HttpResponse } from '@azure/functions'; // 3.5.0

// Context Definiton
export interface Context {
    // ...

    /**
     * HTTP request object. Provided to your function when using HTTP Bindings.
     */
    req?: HttpRequest;
    /**
     * HTTP response object. Provided to your function when using HTTP Bindings.
     */
    res?: {
        [key: string]: any;
    };

    // ...
}
```

Nammatham has override `Context.res` to be `HttpResponse` when the `http` type is already defined in Function Binding
e.g.

```ts
const bindings = [
  // Binding type with `http` type
  Binding.http({ name: 'res' as const }), // make string to literal type
];
```

# Changed

When you defined the functionBinding in correctly type for example

```ts
const bindings = [
  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
  Binding.http({ name: 'res' as const }), // make string to literal type
];
```


## 1. Rename Binding Types

Previously

```ts
Binding.httpTriggerRequest( ... )
Binding.httpTriggerResponse( ... )
```

This change:

```ts
Binding.httpTrigger( ... )
Binding.http( ... )
```

## 2. `this.context.res` will be `HttpResponse` type

`this.context.res` in the abstract class `BaseFunction` is `HttpResponse` when binding type `http`

![CleanShot 2566-02-11 at 18 59 28](https://user-images.githubusercontent.com/3647850/218256808-d7767d14-c744-4bd5-a00e-b872dd2f3ae8.png)

`this.context.res` in the abstract class `BaseFunction` is the original type when no binding type `http`

![CleanShot 2566-02-11 at 19 02 32](https://user-images.githubusercontent.com/3647850/218256896-3feadaef-6ad8-4ff0-b8f9-371e7e5cf000.png)

## 3. `this.context.req` will be `HttpRequest` type

`this.context.req` in the abstract class `BaseFunction` is `HttpRequest` when binding type `httpTrigger`

![CleanShot 2566-02-11 at 19 19 40](https://user-images.githubusercontent.com/3647850/218257611-031ee6f8-502f-46e5-a4ba-c2d1fc8378d5.png)

`this.context.req` in the abstract class `BaseFunction` is `HttpRequest` or `undefined` when no binding type `httpTrigger`

<img width="1107" alt="CleanShot 2566-02-11 at 19 20 54" src="https://user-images.githubusercontent.com/3647850/218257666-b4404e0d-684a-4e71-b529-4aad3affd37c.png">


## 4. `this.res` will be `HttpResponseContext` type

`this.res` in the abstract class `BaseFunction` is `HttpResponseContext` when binding type `http`

> Note:  `HttpResponseContext` is our utility object to handle http response

![CleanShot 2566-02-11 at 19 04 46](https://user-images.githubusercontent.com/3647850/218257000-a480d556-2ac1-41a9-879f-9a4f439c3cca.png)


`this.res` in the abstract class `BaseFunction` is `HttpResponseContext` or undefined when no binding type `http`

![CleanShot 2566-02-11 at 19 07 43](https://user-images.githubusercontent.com/3647850/218257115-171cd8a5-bd8f-4d58-a72e-5a0942dd5a31.png)

## 5. add `this.req`, which will be `HttpRequest` type

`this.req` in the abstract class `BaseFunction` is `HttpRequest` when binding type `httpTrigger`

<img width="1069" alt="CleanShot 2566-02-11 at 19 22 09" src="https://user-images.githubusercontent.com/3647850/218257719-a4b01af4-d43b-43e8-9fc0-224602cccf89.png">

`this.req` in the abstract class `BaseFunction` is `HttpRequest` or `undefined`  when no binding type `httpTrigger`

<img width="983" alt="CleanShot 2566-02-11 at 19 23 46" src="https://user-images.githubusercontent.com/3647850/218257782-6961d9fd-c17c-4d05-94ae-e53271cf8684.png">
