### PR TITLE
feat: Change AuthorizationLevel enum to constant to allow passing the matches string

### DIFF
--- a/packages/core/src/bindings/helpers/http-trigger.ts
+++ b/packages/core/src/bindings/helpers/http-trigger.ts
@@ -1,4 +1,4 @@
-import { AuthorizationLevel, BaseFunctionBinding, Binding, RequestMethod } from '../';
+import { AuthorizationLevelType, BaseFunctionBinding, Binding, RequestMethod } from '../';
 
 /**
  * Built-in Helper,
@@ -9,7 +9,7 @@ import { AuthorizationLevel, BaseFunctionBinding, Binding, RequestMethod } from 
  * @returns
  */
 export function httpTrigger(
-  authLevel: AuthorizationLevel,
+  authLevel: AuthorizationLevelType,
   methods: RequestMethod[],
   route?: string
 ): [BaseFunctionBinding<'httpTrigger', 'req'>, BaseFunctionBinding<'http', 'res'>] {

--- a/packages/core/src/bindings/interfaces/triggers/http-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/http-trigger.binding.ts
@@ -1,9 +1,14 @@
 import { BaseFunctionBinding } from '../base-function-binding';
 
 export type RequestMethod = 'get' | 'post' | 'delete' | 'options' | 'put';
-export enum AuthorizationLevel {
-  Anonymous = 'anonymous',
-}
+
+export const AuthorizationLevel = {
+  Anonymous: 'anonymous',
+  Function: 'function',
+  Admin: 'admin'
+} as const;
+
+export type AuthorizationLevelType = typeof AuthorizationLevel[keyof typeof AuthorizationLevel];
 
 /**
  * Azure Functions Http Trigger Request Type
@@ -28,7 +33,7 @@ export interface httpTriggerBinding<T> extends BaseFunctionBinding<httpTriggerTy
    * Determines what keys, if any, need to be present on the request in order
    * to invoke the function. For supported values, see [Authorization level](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#http-auth).
    */
-  authLevel?: AuthorizationLevel;
+  authLevel?: AuthorizationLevelType;
   /**
    * An array of the HTTP methods to which the function responds. If not specified,
    * the function responds to all HTTP methods. See [customize the HTTP endpoint](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#customize-the-http-endpoint).


### PR DESCRIPTION
Previously, the prop `authLevel` will only accept enum, the user cannot pass the basic string 

```ts
const bindings1 = [
  Binding.httpTrigger({ name: 'req' as const, authLevel: AuthorizationLevel.Anonymous }), // make string to literal type
];

@functionName('httpTriggerHelper', httpTrigger(AuthorizationLevel.Anonymous, ["get"], 'test'))
export class HttpTriggerHelperFunction extends BaseFunction {
  public override execute(){}
}
```

## Changed

The user can pass both `AuthorizationLevel` or matched string (`"function" | "anonymous" | "admin"`)

```ts
const bindings1 = [
  Binding.httpTrigger({ name: 'req' as const, authLevel: AuthorizationLevel.Anonymous }), // make string to literal type
];

const bindings2 = [
  Binding.httpTrigger({ name: 'req' as const, authLevel: 'anonymous' }), // make string to literal type
];

@functionName('httpTriggerHelper', httpTrigger(AuthorizationLevel.Anonymous, ["get"], 'test'))
export class HttpTriggerHelperFunction extends BaseFunction {
  public override execute(){}
}

@functionName('httpTriggerHelper', httpTrigger('anonymous', ["get"], 'test'))
export class HttpTriggerHelperFunction extends BaseFunction {
  public override execute(){}
}
```