### PR TITLE
Improve fluent api for NammthamApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ export class UserService {
 ## Using Inversify API for Binding Services
 
 In some cases, if you want to binding services with [Inversify Container](https://github.com/inversify/InversifyJS/blob/master/wiki/container_api.md) by yourself.
-In the startup file, you can simply get the Container from `builder.getContainer()` as shown in the example below:
+In the startup file, you can simply get the Container from `builder.container` as shown in the example below:
 
 ```ts
 // src/startup.ts
@@ -211,10 +211,8 @@ import { UserFunction } from './functions/user.function';
 
 const builder = NammathamApp.createBuilder(__filename);
 builder.addFunctions(UserFunction);
-// Get container from builder
-const contaienr = builder.getContainer();
 // Using Inversify Container API
-contaienr.bind(Service).toSelf();
+builder.container.bind(Service).toSelf();
 
 builder.build();
 

--- a/examples/basic/src/startup.ts
+++ b/examples/basic/src/startup.ts
@@ -20,8 +20,6 @@ builder.configureServices(services => {
 
 // Singleton objects are the same for every object and every request.
 
-// builder.getContainer().bind(Service).toSelf();
-
 /**
  * Using env var to enable the build process
  */

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -200,7 +200,7 @@ export class UserService {
 ## Using Inversify API for Binding Services
 
 In some cases, if you want to binding services with [Inversify Container](https://github.com/inversify/InversifyJS/blob/master/wiki/container_api.md) by yourself.
-In the startup file, you can simply get the Container from `builder.getContainer()` as shown in the example below:
+In the startup file, you can simply get the Container from `builder.container` as shown in the example below:
 
 ```ts
 // src/startup.ts
@@ -211,10 +211,8 @@ import { UserFunction } from './functions/user.function';
 
 const builder = NammathamApp.createBuilder(__filename);
 builder.addFunctions(UserFunction);
-// Get container from builder
-const contaienr = builder.getContainer();
 // Using Inversify Container API
-contaienr.bind(Service).toSelf();
+builder.container.bind(Service).toSelf();
 
 builder.build();
 

--- a/packages/core/src/bootstrap/function-app-builder.ts
+++ b/packages/core/src/bootstrap/function-app-builder.ts
@@ -15,29 +15,33 @@ interface IFunctionAppBuilderOption {
 export class FunctionAppBuilder {
   protected functionApp!: FunctionApp;
   protected functionAppOption: IFunctionAppOption;
-  protected container: Container;
-  protected services: Services;
+  protected _container: Container;
+  protected _services: Services;
 
   constructor(bootstrapPath: string, option?: IFunctionAppBuilderOption) {
-    this.container = option?.container ?? new Container();
-    this.services = new Services(this.container);
+    this._container = option?.container ?? new Container();
+    this._services = new Services(this._container);
     this.functionAppOption = {
       bootstrapPath,
-      container: this.container,
+      container: this._container,
       controllers: [],
     };
   }
 
   public setContainer(container: Container) {
-    this.container = container;
+    this._container = container;
   }
 
-  public getContainer() {
-    return this.container;
+  get container() {
+    return this._container;
+  }
+
+  get services(){
+    return this._services;
   }
 
   public configureServices(callback: (services: Services) => void) {
-    callback(this.services);
+    callback(this._services);
   }
 
   /**
@@ -82,7 +86,7 @@ export class FunctionAppBuilder {
     /**
      * Binding at root in both build & runtime mode
      */
-    this.functionApp.bindControllersWithContainer(this.container);
+    this.functionApp.bindControllersWithContainer(this._container);
     /**
      * Deciding run mode
      */


### PR DESCRIPTION
## Get Container

Before

```ts
builder.getContainer().bind(Service).toSelf();
```

after

```ts
builder.container.bind(Service).toSelf();
```

## Services API

When we don't want to use `builder.configureServices()`, you can use like this.

```ts
builder.services.addSingleton(MyService);
``` 

## Example

```ts
// src/startup.ts
import 'reflect-metadata';
import { NammathamApp } from 'nammatham';
import { UserService } from './services/user.services';
import { UserFunction } from './functions/user.function';
import { MyService } from './services/my.services';

const builder = NammathamApp.createBuilder(__filename);
builder.addFunctions(UserFunction);
// Using Inversify Container API
builder.container.bind(Service).toSelf();
// Add services with Nammatham helper API
builder.services.addSingleton(MyService);

builder.build();

export default builder.getApp();
```