### PR TITLE
 Fix: cosmosDB input & output binding helper function following Azure Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ Nammatham (นามธรรม in Thai, pronounced `/naam ma tham/`, means **a
 
 [![Build & Test](https://github.com/mildronize/nammatham/actions/workflows/test.yml/badge.svg)](https://github.com/mildronize/nammatham/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/mildronize/nammatham/branch/main/graph/badge.svg?token=Y7ZMDKFPAN)](https://codecov.io/gh/mildronize/nammatham) [![npm version](https://img.shields.io/npm/v/nammatham)](https://www.npmjs.com/package/nammatham) [![npm download](https://img.shields.io/npm/dt/nammatham)](https://www.npmjs.com/package/nammatham)
 
+## Compatibility with Azure Functions
+- [Azure Function NodeJs](https://github.com/Azure/azure-functions-nodejs-worker/) : v3.x (`@azure/functions`)
+- [Runtime Version](https://docs.microsoft.com/azure/azure-functions/functions-versions): 4 ([Source Code](https://github.dev/Azure/azure-functions-host/tree/release/4.x))
+- Node.js Versions: 16, 18
+
+
 ## Introduction
 
 Azure Functions is a platform for building event-driven and serverless applications. **Nammatham** is a framework that allows you to use Azure Functions with TypeScript and decorators. It provides pre-defined JSON binding objects and utility functions, such as `httpTrigger`, to make it easier to create Azure Functions.

--- a/docs/binding-type.md
+++ b/docs/binding-type.md
@@ -5,7 +5,7 @@ You can see all built-in binding type in [test case](packages/core/src/test-usec
 ```ts
 import { BaseFunction, Binding, functionName } from '../../../../main';
 import { responseHelper } from '../../../response-helper';
-import { HttpRequest, HttpResponse, Timer} from '@azure/functions';
+import { HttpRequest, HttpResponse, Timer } from '@azure/functions';
 
 const bindings = [
   Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
@@ -13,41 +13,72 @@ const bindings = [
   Binding.http_withReturn(),
   Binding.timerTrigger({ name: 'timer' as const, schedule: '*' }), // make string to literal type
   Binding.cosmosDBTrigger_v2({
-    name: 'document_input_v2' as const,
+    name: 'document_trigger_v2',
     collectionName: '',
-    databaseName: '',
-    connectionStringSetting: '' ,
-  }),
-  Binding.cosmosDB_output_v2({
-    name: 'document_output_v2' as const,
-    collectionName: '',
-    createIfNotExists: true,
-    databaseName: '',
-    partitionKey: ''
-  }),
-  Binding.cosmosDBTrigger_v4({
-    name: 'document_input_v4' as const,
     connection: '',
+    connectionStringSetting: '',
     containerName: '',
     databaseName: '',
   }),
-  Binding.cosmosDB_output_v4({
-    name: 'document_output_v4' as const,
+  Binding.cosmosDBTrigger_v4({
+    name: 'document_trigger_v4' as const,
     connection: '',
     containerName: '',
     databaseName: '',
   }),
   Binding.cosmosDBTrigger({
-    name: 'document_input_default' as const,
+    name: 'document_trigger_default' as const,
     connection: '',
     containerName: '',
     databaseName: '',
   }),
-  Binding.cosmosDB_output({
-    name: 'document_output_default' as const,
+  Binding.cosmosDB_output_v2({
+    name: 'document_output_v2' as const,
+    collectionName: '',
+    connectionStringSetting: '',
+    createIfNotExists: true,
+    databaseName: '',
+  }),
+  Binding.cosmosDB_output_v4({
+    name: 'document_output_v4' as const,
+    createIfNotExists: true,
+    databaseName: '',
     connection: '',
     containerName: '',
+  }),
+  Binding.cosmosDB_output({
+    name: 'document_output_default' as const,
+    createIfNotExists: true,
     databaseName: '',
+    connection: '',
+    containerName: '',
+  }),
+  Binding.cosmosDB_input_v2({
+    name: 'document_input_v2' as const,
+    collectionName: '',
+    connectionStringSetting: '',
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+  }),
+  Binding.cosmosDB_input_v4({
+    name: 'document_input_v4' as const,
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+    connection: '',
+    containerName: '',
+  }),
+  Binding.cosmosDB_input({
+    name: 'document_input_default' as const,
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+    connection: '',
+    containerName: '',
   }),
 ] as const;
 
@@ -59,12 +90,19 @@ export class AllBindingsFunction extends BaseFunction<typeof bindings> {
     const req: HttpRequest = this.bindings.req;
     const res: HttpResponse = this.bindings.res;
     const timer: Timer = this.bindings.timer;
-    const document_input_v2: any = this.bindings.document_input_v2;
+
     const document_output_v2: any = this.bindings.document_output_v2;
-    const document_input_v4: any = this.bindings.document_input_v4;
     const document_output_v4: any = this.bindings.document_output_v4;
-    const document_input_default: any = this.bindings.document_input_default;
     const document_output_default: any = this.bindings.document_output_default;
+
+    const document_input_v2: any = this.bindings.document_input_v2;
+    const document_input_v4: any = this.bindings.document_input_v4;
+    const document_input_default: any = this.bindings.document_input_default;
+
+    const document_trigger_v2: any = this.bindings.document_trigger_v2;
+    const document_trigger_v4: any = this.bindings.document_trigger_v4;
+    const document_trigger_default: any = this.bindings.document_trigger_default;
+
     const { name } = this.req.query;
     this.res.send(responseHelper(name));
   }

--- a/docs/binding-type.md
+++ b/docs/binding-type.md
@@ -10,7 +10,7 @@ import { HttpRequest, HttpResponse, Timer} from '@azure/functions';
 const bindings = [
   Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
   Binding.http({ name: 'res' as const }), // make string to literal type
-  Binding.httpWithReturn(),
+  Binding.http_withReturn(),
   Binding.timerTrigger({ name: 'timer' as const, schedule: '*' }), // make string to literal type
   Binding.cosmosDBTrigger_v2({
     name: 'document_input_v2' as const,
@@ -18,7 +18,7 @@ const bindings = [
     databaseName: '',
     connectionStringSetting: '' ,
   }),
-  Binding.cosmosDB_v2({
+  Binding.cosmosDB_output_v2({
     name: 'document_output_v2' as const,
     collectionName: '',
     createIfNotExists: true,
@@ -31,7 +31,7 @@ const bindings = [
     containerName: '',
     databaseName: '',
   }),
-  Binding.cosmosDB_v4({
+  Binding.cosmosDB_output_v4({
     name: 'document_output_v4' as const,
     connection: '',
     containerName: '',
@@ -43,7 +43,7 @@ const bindings = [
     containerName: '',
     databaseName: '',
   }),
-  Binding.cosmosDB({
+  Binding.cosmosDB_output({
     name: 'document_output_default' as const,
     connection: '',
     containerName: '',

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -12,3 +12,12 @@ npx nx run nammatham:test:watch
 # Publish npm with nx
 pnpm --filter nammatham publish
 ```
+
+## Azure Functions Ecosystem
+- Azure Functions Node.js: https://github.com/Azure/azure-functions-nodejs-worker (v3.x)
+- [Azure Function Runtime (Host)](https://github.dev/Azure/azure-functions-host/tree/release/4.x) v4.x
+- The Azure Functions runtime builds upon the [Azure WebJobs SDK](https://github.com/Azure/azure-webjobs-sdk) to provide a hosting platform for functions written in many different [languages](https://docs.microsoft.com/en-us/azure/azure-functions/supported-languages) and supporting a wide variety of [triggers and bindings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings?tabs=csharp#supported-bindings)
+  - Azure WebJobs SDK use [Azure WebJobs SDK Extensions](https://github.com/Azure/azure-webjobs-sdk-extensions)
+  - In addition to the built in triggers/bindings, the WebJobs SDK is **fully extensible**, allowing new types of triggers/bindings to be created and plugged into the framework in a first class way. See [Azure WebJobs SDK Extensions](https://github.com/Azure/azure-webjobs-sdk-extensions) for details. Many useful extensions have already been created and can be used in your applications today. Extensions include a File trigger/binder, a Timer/Cron trigger, a WebHook HTTP trigger, as well as a SendGrid email binding. 
+- [Register Azure Functions binding extensions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-register)
+  - Need to install `Microsoft.Azure.Functions.ExtensionBundle` in `host.json` which is in https://github.com/Azure/azure-functions-extension-bundles

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,6 +3,12 @@ Nammatham (นามธรรม in Thai, pronounced `/naam ma tham/`, means **a
 
 [![Build & Test](https://github.com/mildronize/nammatham/actions/workflows/test.yml/badge.svg)](https://github.com/mildronize/nammatham/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/mildronize/nammatham/branch/main/graph/badge.svg?token=Y7ZMDKFPAN)](https://codecov.io/gh/mildronize/nammatham) [![npm version](https://img.shields.io/npm/v/nammatham)](https://www.npmjs.com/package/nammatham) [![npm download](https://img.shields.io/npm/dt/nammatham)](https://www.npmjs.com/package/nammatham)
 
+## Compatibility with Azure Functions
+- [Azure Function NodeJs](https://github.com/Azure/azure-functions-nodejs-worker/) : v3.x (`@azure/functions`)
+- [Runtime Version](https://docs.microsoft.com/azure/azure-functions/functions-versions): 4 ([Source Code](https://github.dev/Azure/azure-functions-host/tree/release/4.x))
+- Node.js Versions: 16, 18
+
+
 ## Introduction
 
 Azure Functions is a platform for building event-driven and serverless applications. **Nammatham** is a framework that allows you to use Azure Functions with TypeScript and decorators. It provides pre-defined JSON binding objects and utility functions, such as `httpTrigger`, to make it easier to create Azure Functions.

--- a/packages/core/src/bindings/binding/cosmos-db-trigger.ts
+++ b/packages/core/src/bindings/binding/cosmos-db-trigger.ts
@@ -1,9 +1,9 @@
 import type { PartialBy } from '../../types';
 import {
-  CosmosDBTriggerBinding_v4,
-  CosmosDBTriggerBinding_v2,
-  CosmosDBBinding_Output_v2,
-  CosmosDBBinding_Output_v4,
+  CosmosDBTriggerBinding_V4,
+  CosmosDBTriggerBinding_V2,
+  CosmosDBBinding_Output_V2,
+  CosmosDBBinding_Output_V4,
 } from '../interfaces';
 
 /**
@@ -38,12 +38,12 @@ import {
     ```
    @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
- * @param bindings - `CosmosDBTriggerBinding_v4`
- * @returns `CosmosDBTriggerBinding_v4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
+ * @param bindings - `CosmosDBTriggerBinding_V4`
+ * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
 export function cosmosDBTrigger_v2<
-  T extends PartialBy<CosmosDBTriggerBinding_v2<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBTriggerBinding_v2<T['name']> {
+  T extends PartialBy<CosmosDBTriggerBinding_V2<unknown>, 'type' | 'direction'>
+>(bindings: T): CosmosDBTriggerBinding_V2<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDBTrigger',
@@ -83,12 +83,12 @@ export function cosmosDBTrigger_v2<
     ```
    @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
- * @param bindings - `CosmosDBTriggerBinding_v4`
- * @returns `CosmosDBTriggerBinding_v4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
+ * @param bindings - `CosmosDBTriggerBinding_V4`
+ * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
 export function cosmosDBTrigger_v4<
-  T extends PartialBy<CosmosDBTriggerBinding_v4<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBTriggerBinding_v4<T['name']> {
+  T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>
+>(bindings: T): CosmosDBTriggerBinding_V4<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDBTrigger',
@@ -128,11 +128,11 @@ export function cosmosDBTrigger_v4<
     ```
    @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
- * @param bindings - `CosmosDBTriggerBinding_v4`
- * @returns `CosmosDBTriggerBinding_v4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
+ * @param bindings - `CosmosDBTriggerBinding_V4`
+ * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
 export function cosmosDBTrigger<
-  T extends PartialBy<CosmosDBTriggerBinding_v4<unknown>, 'type' | 'direction'>
+  T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>
 >(bindings: T) {
   return cosmosDBTrigger_v4(bindings);
 }
@@ -169,12 +169,12 @@ export function cosmosDBTrigger<
     ```
    @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
- * @param bindings - `CosmosDBBinding_Output_v2`
- * @returns `CosmosDBBinding_Output_v2` Object with `{ type: 'cosmosDB', direction: 'out' }`
+ * @param bindings - `CosmosDBBinding_Output_V2`
+ * @returns `CosmosDBBinding_Output_V2` Object with `{ type: 'cosmosDB', direction: 'out' }`
  */
 export function cosmosDB_output_v2<
-  T extends PartialBy<CosmosDBBinding_Output_v2<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBBinding_Output_v2<T['name']> {
+  T extends PartialBy<CosmosDBBinding_Output_V2<unknown>, 'type' | 'direction'>
+>(bindings: T): CosmosDBBinding_Output_V2<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -214,12 +214,12 @@ export function cosmosDB_output_v2<
     ```
     @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
-  * @param bindings - `CosmosDBBinding_Output_v4`
-  * @returns `CosmosDBBinding_Output_v4` Object with `{ type: 'cosmosDB', direction: 'out' }`
+  * @param bindings - `CosmosDBBinding_Output_V4`
+  * @returns `CosmosDBBinding_Output_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
 export function cosmosDB_output_v4<
-  T extends PartialBy<CosmosDBBinding_Output_v4<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBBinding_Output_v4<T['name']> {
+  T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>
+>(bindings: T): CosmosDBBinding_Output_V4<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -259,11 +259,11 @@ export function cosmosDB_output_v4<
     ```
     @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
-  * @param bindings - `CosmosDBBinding_Output_v4`
-  * @returns `CosmosDBBinding_Output_v4` Object with `{ type: 'cosmosDB', direction: 'out' }`
+  * @param bindings - `CosmosDBBinding_Output_V4`
+  * @returns `CosmosDBBinding_Output_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
 export function cosmosDB_output<
-  T extends PartialBy<CosmosDBBinding_Output_v4<unknown>, 'type' | 'direction'>
+  T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>
 >(bindings: T) {
   return cosmosDB_output_v4(bindings);
 }

--- a/packages/core/src/bindings/binding/cosmos-db-trigger.ts
+++ b/packages/core/src/bindings/binding/cosmos-db-trigger.ts
@@ -4,6 +4,8 @@ import {
   CosmosDBTriggerBinding_V2,
   CosmosDBBinding_Output_V2,
   CosmosDBBinding_Output_V4,
+  CosmosDBBinding_Input_V2,
+  CosmosDBBinding_Input_V4,
 } from '../interfaces';
 
 /**
@@ -41,9 +43,9 @@ import {
  * @param bindings - `CosmosDBTriggerBinding_V4`
  * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
-export function cosmosDBTrigger_v2<
-  T extends PartialBy<CosmosDBTriggerBinding_V2<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBTriggerBinding_V2<T['name']> {
+export function cosmosDBTrigger_v2<T extends PartialBy<CosmosDBTriggerBinding_V2<unknown>, 'type' | 'direction'>>(
+  bindings: T
+): CosmosDBTriggerBinding_V2<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDBTrigger',
@@ -86,9 +88,9 @@ export function cosmosDBTrigger_v2<
  * @param bindings - `CosmosDBTriggerBinding_V4`
  * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
-export function cosmosDBTrigger_v4<
-  T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBTriggerBinding_V4<T['name']> {
+export function cosmosDBTrigger_v4<T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>>(
+  bindings: T
+): CosmosDBTriggerBinding_V4<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDBTrigger',
@@ -131,9 +133,9 @@ export function cosmosDBTrigger_v4<
  * @param bindings - `CosmosDBTriggerBinding_V4`
  * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
-export function cosmosDBTrigger<
-  T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>
->(bindings: T) {
+export function cosmosDBTrigger<T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>>(
+  bindings: T
+) {
   return cosmosDBTrigger_v4(bindings);
 }
 
@@ -172,9 +174,9 @@ export function cosmosDBTrigger<
  * @param bindings - `CosmosDBBinding_Output_V2`
  * @returns `CosmosDBBinding_Output_V2` Object with `{ type: 'cosmosDB', direction: 'out' }`
  */
-export function cosmosDB_output_v2<
-  T extends PartialBy<CosmosDBBinding_Output_V2<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBBinding_Output_V2<T['name']> {
+export function cosmosDB_output_v2<T extends PartialBy<CosmosDBBinding_Output_V2<unknown>, 'type' | 'direction'>>(
+  bindings: T
+): CosmosDBBinding_Output_V2<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -217,9 +219,9 @@ export function cosmosDB_output_v2<
   * @param bindings - `CosmosDBBinding_Output_V4`
   * @returns `CosmosDBBinding_Output_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
-export function cosmosDB_output_v4<
-  T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBBinding_Output_V4<T['name']> {
+export function cosmosDB_output_v4<T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>>(
+  bindings: T
+): CosmosDBBinding_Output_V4<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -262,8 +264,139 @@ export function cosmosDB_output_v4<
   * @param bindings - `CosmosDBBinding_Output_V4`
   * @returns `CosmosDBBinding_Output_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
-export function cosmosDB_output<
-  T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>
->(bindings: T) {
+export function cosmosDB_output<T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>>(
+  bindings: T
+) {
   return cosmosDB_output_v4(bindings);
+}
+
+/**
+ * Create cosmosDB type binding for Bundle Extension v2 or v3. It requires to install [Bundle extension v2 or v3](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#install-bundle)
+ * 
+ * Use for Binding input with [cosmosDB Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
+ * 
+ * @example
+ *  ```
+    // Option 1: Using cosmosDB implicitly 
+    Binding.cosmosDB_input_v2({ name: 'documents' as const })
+
+    // Option 2: Using cosmosDB explicitly
+    Binding.cosmosDB_input_v2({ 
+      name: 'documents' as const,
+      direction: 'out',
+      type: 'cosmosDB'
+    })
+    ```
+
+    Passing that object into `@functionName` decorator, At boostrap phase, Nammatham will generate binding `function.json` like:
+    ```json
+    {
+      "bindings": [
+        {
+          "name": "documents",
+          "direction": "out",
+          "type": "cosmosDB"
+        }
+      ]
+    }
+    ```
+   @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
+
+ * @param bindings - `CosmosDBBinding_Input_V2`
+ * @returns `CosmosDBBinding_Input_V2` Object with `{ type: 'cosmosDB', direction: 'out' }`
+ */
+export function cosmosDB_input_v2<T extends PartialBy<CosmosDBBinding_Input_V2<unknown>, 'type' | 'direction'>>(
+  bindings: T
+): CosmosDBBinding_Input_V2<T['name']> {
+  return {
+    ...bindings,
+    type: 'cosmosDB',
+    direction: 'out',
+  };
+}
+
+/**
+  * Create cosmosDB type binding for Bundle Extension v4. It required to install [Bundle extension v4](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#install-bundle)
+  * 
+  * Use for Binding input with [cosmosDB Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
+  * 
+  * @example
+  *  ```
+     // Option 1: Using cosmosDB implicitly 
+     Binding.cosmosDB_input_v4({ name: 'documents' as const })
+ 
+     // Option 2: Using cosmosDB explicitly
+     Binding.cosmosDB_input_v4({ 
+       name: 'documents' as const,
+       direction: 'out',
+       type: 'cosmosDB'
+     })
+     ```
+ 
+     Passing that object into `@functionName` decorator, At boostrap phase, Nammatham will generate binding `function.json` like:
+     ```json
+     {
+       "bindings": [
+         {
+           "name": "documents",
+           "direction": "out",
+           "type": "cosmosDB"
+         }
+       ]
+     }
+     ```
+     @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
+ 
+   * @param bindings - `CosmosDBBinding_Input_V4`
+   * @returns `CosmosDBBinding_Input_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
+   */
+export function cosmosDB_input_v4<T extends PartialBy<CosmosDBBinding_Input_V4<unknown>, 'type' | 'direction'>>(
+  bindings: T
+): CosmosDBBinding_Input_V4<T['name']> {
+  return {
+    ...bindings,
+    type: 'cosmosDB',
+    direction: 'out',
+  };
+}
+
+/**
+  * Create cosmosDB type binding for Bundle Extension v4. It required to install [Bundle extension v4](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#install-bundle)
+  * 
+  * Use for Binding input with [cosmosDB Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
+  * 
+  * @example
+  *  ```
+     // Option 1: Using cosmosDB implicitly 
+     Binding.cosmosDB_input({ name: 'documents' as const })
+ 
+     // Option 2: Using cosmosDB explicitly
+     Binding.cosmosDB_input({ 
+       name: 'documents' as const,
+       direction: 'out',
+       type: 'cosmosDB'
+     })
+     ```
+ 
+     Passing that object into `@functionName` decorator, At boostrap phase, Nammatham will generate binding `function.json` like:
+     ```json
+     {
+       "bindings": [
+         {
+           "name": "documents",
+           "direction": "out",
+           "type": "cosmosDB"
+         }
+       ]
+     }
+     ```
+     @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
+ 
+   * @param bindings - `CosmosDBBinding_Input_V4`
+   * @returns `CosmosDBBinding_Input_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
+   */
+export function cosmosDB_input<T extends PartialBy<CosmosDBBinding_Input_V4<unknown>, 'type' | 'direction'>>(
+  bindings: T
+) {
+  return cosmosDB_input_v4(bindings);
 }

--- a/packages/core/src/bindings/binding/cosmos-db-trigger.ts
+++ b/packages/core/src/bindings/binding/cosmos-db-trigger.ts
@@ -2,8 +2,8 @@ import type { PartialBy } from '../../types';
 import {
   CosmosDBTriggerBinding_v4,
   CosmosDBTriggerBinding_v2,
-  CosmosDBBinding_v2,
-  CosmosDBBinding_v4,
+  CosmosDBBinding_Output_v2,
+  CosmosDBBinding_Output_v4,
 } from '../interfaces';
 
 /**
@@ -145,10 +145,10 @@ export function cosmosDBTrigger<
  * @example
  *  ```
     // Option 1: Using cosmosDB implicitly 
-    Binding.cosmosDB_v2({ name: 'documents' as const })
+    Binding.cosmosDB_output_v2({ name: 'documents' as const })
 
     // Option 2: Using cosmosDB explicitly
-    Binding.cosmosDB_v2({ 
+    Binding.cosmosDB_output_v2({ 
       name: 'documents' as const,
       direction: 'out',
       type: 'cosmosDB'
@@ -169,12 +169,12 @@ export function cosmosDBTrigger<
     ```
    @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
- * @param bindings - `CosmosDBBinding_v2`
- * @returns `CosmosDBBinding_v2` Object with `{ type: 'cosmosDB', direction: 'out' }`
+ * @param bindings - `CosmosDBBinding_Output_v2`
+ * @returns `CosmosDBBinding_Output_v2` Object with `{ type: 'cosmosDB', direction: 'out' }`
  */
-export function cosmosDB_v2<
-  T extends PartialBy<CosmosDBBinding_v2<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBBinding_v2<T['name']> {
+export function cosmosDB_output_v2<
+  T extends PartialBy<CosmosDBBinding_Output_v2<unknown>, 'type' | 'direction'>
+>(bindings: T): CosmosDBBinding_Output_v2<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -190,10 +190,10 @@ export function cosmosDB_v2<
  * @example
  *  ```
     // Option 1: Using cosmosDB implicitly 
-    Binding.cosmosDB_v4({ name: 'documents' as const })
+    Binding.cosmosDB_output_v4({ name: 'documents' as const })
 
     // Option 2: Using cosmosDB explicitly
-    Binding.cosmosDB_v4({ 
+    Binding.cosmosDB_output_v4({ 
       name: 'documents' as const,
       direction: 'out',
       type: 'cosmosDB'
@@ -214,12 +214,12 @@ export function cosmosDB_v2<
     ```
     @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
-  * @param bindings - `CosmosDBBinding_v4`
-  * @returns `CosmosDBBinding_v4` Object with `{ type: 'cosmosDB', direction: 'out' }`
+  * @param bindings - `CosmosDBBinding_Output_v4`
+  * @returns `CosmosDBBinding_Output_v4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
-export function cosmosDB_v4<
-  T extends PartialBy<CosmosDBBinding_v4<unknown>, 'type' | 'direction'>
->(bindings: T): CosmosDBBinding_v4<T['name']> {
+export function cosmosDB_output_v4<
+  T extends PartialBy<CosmosDBBinding_Output_v4<unknown>, 'type' | 'direction'>
+>(bindings: T): CosmosDBBinding_Output_v4<T['name']> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -235,10 +235,10 @@ export function cosmosDB_v4<
  * @example
  *  ```
     // Option 1: Using cosmosDB implicitly 
-    Binding.cosmosDB({ name: 'documents' as const })
+    Binding.cosmosDB_output({ name: 'documents' as const })
 
     // Option 2: Using cosmosDB explicitly
-    Binding.cosmosDB({ 
+    Binding.cosmosDB_output({ 
       name: 'documents' as const,
       direction: 'out',
       type: 'cosmosDB'
@@ -259,11 +259,11 @@ export function cosmosDB_v4<
     ```
     @remark Always mark the name prop `as const`, to convert the string into literal type. So, the Nammatham will detect only literal type to map the binding object in `Context`
 
-  * @param bindings - `CosmosDBBinding_v4`
-  * @returns `CosmosDBBinding_v4` Object with `{ type: 'cosmosDB', direction: 'out' }`
+  * @param bindings - `CosmosDBBinding_Output_v4`
+  * @returns `CosmosDBBinding_Output_v4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
-export function cosmosDB<
-  T extends PartialBy<CosmosDBBinding_v4<unknown>, 'type' | 'direction'>
+export function cosmosDB_output<
+  T extends PartialBy<CosmosDBBinding_Output_v4<unknown>, 'type' | 'direction'>
 >(bindings: T) {
-  return cosmosDB_v4(bindings);
+  return cosmosDB_output_v4(bindings);
 }

--- a/packages/core/src/bindings/binding/http.ts
+++ b/packages/core/src/bindings/binding/http.ts
@@ -54,10 +54,10 @@ export function http<T extends PartialBy<HttpBinding<unknown>, 'type' | 'directi
    * @example
    *  ```
       // Option 1: Using http implicitly 
-      Binding.httpWithReturn()
+      Binding.http_withReturn()
   
       // Option 2: Using http explicitly
-      Binding.httpWithReturn({ 
+      Binding.http_withReturn({ 
         name: '$return' as const,
         direction: 'out',
         type: 'http'
@@ -80,7 +80,7 @@ export function http<T extends PartialBy<HttpBinding<unknown>, 'type' | 'directi
    * @param bindings - `HttpBinding` (Optional)
    * @returns `HttpBinding` Object with  `{ name: '$return', type: 'http', direction: 'out' }`
    */
-export function httpWithReturn<T extends PartialBy<HttpBinding<unknown>, 'name' | 'type' | 'direction'>>(
+export function http_withReturn<T extends PartialBy<HttpBinding<unknown>, 'name' | 'type' | 'direction'>>(
   bindings?: T
 ): HttpBinding<'$return'> {
   bindings = bindings ?? ({} as T);

--- a/packages/core/src/bindings/binding/index.ts
+++ b/packages/core/src/bindings/binding/index.ts
@@ -9,6 +9,9 @@ import {
   cosmosDB_output,
   cosmosDB_output_v2,
   cosmosDB_output_v4,
+  cosmosDB_input,
+  cosmosDB_input_v2,
+  cosmosDB_input_v4
 } from './cosmos-db-trigger';
 
 export default {
@@ -23,4 +26,7 @@ export default {
   cosmosDB_output,
   cosmosDB_output_v2,
   cosmosDB_output_v4,
+  cosmosDB_input,
+  cosmosDB_input_v2,
+  cosmosDB_input_v4
 };

--- a/packages/core/src/bindings/binding/index.ts
+++ b/packages/core/src/bindings/binding/index.ts
@@ -1,26 +1,26 @@
 import { custom } from './custom';
 import { httpTrigger } from './http-trigger';
-import { http, httpWithReturn } from './http';
+import { http, http_withReturn } from './http';
 import { timerTrigger } from './timer-trigger';
 import {
   cosmosDBTrigger,
   cosmosDBTrigger_v2,
   cosmosDBTrigger_v4,
-  cosmosDB,
-  cosmosDB_v2,
-  cosmosDB_v4,
+  cosmosDB_output,
+  cosmosDB_output_v2,
+  cosmosDB_output_v4,
 } from './cosmos-db-trigger';
 
 export default {
   httpTrigger,
   http,
-  httpWithReturn,
+  http_withReturn,
   timerTrigger,
   custom,
   cosmosDBTrigger,
   cosmosDBTrigger_v2,
   cosmosDBTrigger_v4,
-  cosmosDB,
-  cosmosDB_v2,
-  cosmosDB_v4,
+  cosmosDB_output,
+  cosmosDB_output_v2,
+  cosmosDB_output_v4,
 };

--- a/packages/core/src/bindings/interfaces/function-binding.ts
+++ b/packages/core/src/bindings/interfaces/function-binding.ts
@@ -7,6 +7,8 @@ import {
   CosmosDBTriggerBinding_V4,
   CosmosDBBinding_Output_V2,
   CosmosDBBinding_Output_V4,
+  CosmosDBBinding_Input_V2,
+  CosmosDBBinding_Input_V4
 } from './triggers';
 
 export type DefinedFunctionBinding<T extends unknown> =
@@ -16,7 +18,9 @@ export type DefinedFunctionBinding<T extends unknown> =
   | CosmosDBTriggerBinding_V2<T>
   | CosmosDBTriggerBinding_V4<T>
   | CosmosDBBinding_Output_V2<T>
-  | CosmosDBBinding_Output_V4<T>;
+  | CosmosDBBinding_Output_V4<T>
+  | CosmosDBBinding_Input_V2<T>
+  | CosmosDBBinding_Input_V4<T>;
 
 /**
  * If `T` type is `null`, then return `DefinedFunctionBinding`,

--- a/packages/core/src/bindings/interfaces/function-binding.ts
+++ b/packages/core/src/bindings/interfaces/function-binding.ts
@@ -5,8 +5,8 @@ import {
   TimerTriggerBinding,
   CosmosDBTriggerBinding_v2,
   CosmosDBTriggerBinding_v4,
-  CosmosDBBinding_v2,
-  CosmosDBBinding_v4,
+  CosmosDBBinding_Output_v2,
+  CosmosDBBinding_Output_v4,
 } from './triggers';
 
 export type DefinedFunctionBinding<T extends unknown> =
@@ -15,8 +15,8 @@ export type DefinedFunctionBinding<T extends unknown> =
   | TimerTriggerBinding<T>
   | CosmosDBTriggerBinding_v2<T>
   | CosmosDBTriggerBinding_v4<T>
-  | CosmosDBBinding_v2<T>
-  | CosmosDBBinding_v4<T>;
+  | CosmosDBBinding_Output_v2<T>
+  | CosmosDBBinding_Output_v4<T>;
 
 /**
  * If `T` type is `null`, then return `DefinedFunctionBinding`,

--- a/packages/core/src/bindings/interfaces/function-binding.ts
+++ b/packages/core/src/bindings/interfaces/function-binding.ts
@@ -3,20 +3,20 @@ import {
   HttpTriggerBinding,
   HttpBinding,
   TimerTriggerBinding,
-  CosmosDBTriggerBinding_v2,
-  CosmosDBTriggerBinding_v4,
-  CosmosDBBinding_Output_v2,
-  CosmosDBBinding_Output_v4,
+  CosmosDBTriggerBinding_V2,
+  CosmosDBTriggerBinding_V4,
+  CosmosDBBinding_Output_V2,
+  CosmosDBBinding_Output_V4,
 } from './triggers';
 
 export type DefinedFunctionBinding<T extends unknown> =
   | HttpTriggerBinding<T>
   | HttpBinding<T>
   | TimerTriggerBinding<T>
-  | CosmosDBTriggerBinding_v2<T>
-  | CosmosDBTriggerBinding_v4<T>
-  | CosmosDBBinding_Output_v2<T>
-  | CosmosDBBinding_Output_v4<T>;
+  | CosmosDBTriggerBinding_V2<T>
+  | CosmosDBTriggerBinding_V4<T>
+  | CosmosDBBinding_Output_V2<T>
+  | CosmosDBBinding_Output_V4<T>;
 
 /**
  * If `T` type is `null`, then return `DefinedFunctionBinding`,

--- a/packages/core/src/bindings/interfaces/triggers/cosmos-db-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/cosmos-db-trigger.binding.ts
@@ -9,17 +9,43 @@ export type CosmosDBTriggerType = 'cosmosDBTrigger';
  * CosmosDBTrigger Type v2 with [cosmosDBTrigger Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
  */
 
-export interface CosmosDBTriggerBinding_V2<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
+interface CosmosDBTriggerBinding_Base<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
   /**
    * Required - Must be set to `cosmosDBTrigger`.
    */
   type: CosmosDBTriggerType;
 
   direction: 'in';
+
   /**
    * The name of the Azure Cosmos DB database with the collection being monitored.
    */
   databaseName: string;
+
+  /** 
+  (Optional) The name of the database that holds the collection used to store leases. When not set, the value of the databaseName setting is used.
+  */
+  leaseDatabaseName?: any;
+  /** 
+  (Optional) The time (in milliseconds) for the delay between polling a partition for new changes on the feed, after all current changes are drained. Default is 5,000 milliseconds, or 5 seconds.
+  */
+  feedPollDelay?: any;
+
+  /** 
+  (Optional) When set, it defines, in milliseconds, the interval to kick off a task to compute if partitions are distributed evenly among known host instances. Default is 13000 (13 seconds).
+  */
+  leaseAcquireInterval?: any;
+  /** 
+  (Optional) When set, it defines, in milliseconds, the interval for which the lease is taken on a lease representing a partition. If the lease is not renewed within this interval, it will cause it to expire and ownership of the partition will move to another instance. Default is 60000 (60 seconds).
+  */
+  leaseExpirationInterval?: any;
+}
+
+/**
+ * CosmosDBTrigger Type v2 with [cosmosDBTrigger Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
+ */
+
+export interface CosmosDBTriggerBinding_V2<Name> extends CosmosDBTriggerBinding_Base<Name> {
   /**
    * The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see [Connections](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#connections).
    */
@@ -35,10 +61,7 @@ export interface CosmosDBTriggerBinding_V2<Name> extends BaseFunctionBinding<Cos
   When not set, the connectionStringSetting value is used. This parameter is automatically set when the binding is created in the portal. The connection string for the leases collection must have write permissions.
   */
   leaseConnectionStringSetting?: any;
-  /** 
-  (Optional) The name of the database that holds the collection used to store leases. When not set, the value of the databaseName setting is used.
-  */
-  leaseDatabaseName?: any;
+
   /** 
   (Optional) The name of the collection used to store leases. When not set, the value leases is used.
   */
@@ -55,18 +78,7 @@ export interface CosmosDBTriggerBinding_V2<Name> extends BaseFunctionBinding<Cos
   (Optional) When set, the value is added as a prefix to the leases created in the Lease collection for this function. Using a prefix allows two separate Azure Functions to share the same Lease collection by using different prefixes.
   */
   leaseCollectionPrefix?: any;
-  /** 
-  (Optional) The time (in milliseconds) for the delay between polling a partition for new changes on the feed, after all current changes are drained. Default is 5,000 milliseconds, or 5 seconds.
-  */
-  feedPollDelay?: any;
-  /** 
-  (Optional) When set, it defines, in milliseconds, the interval to kick off a task to compute if partitions are distributed evenly among known host instances. Default is 13000 (13 seconds).
-  */
-  leaseAcquireInterval?: any;
-  /** 
-  (Optional) When set, it defines, in milliseconds, the interval for which the lease is taken on a lease representing a partition. If the lease is not renewed within this interval, it will cause it to expire and ownership of the partition will move to another instance. Default is 60000 (60 seconds).
-  */
-  leaseExpirationInterval?: any;
+
   /** 
   (Optional) When set, it defines, in milliseconds, the renew interval for all leases for partitions currently held by an instance. Default is 17000 (17 seconds).
   */
@@ -100,17 +112,7 @@ export interface CosmosDBTriggerBinding_V2<Name> extends BaseFunctionBinding<Cos
 /**
  * CosmosDBTrigger Type v4 with [cosmosDBTrigger Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
  */
-export interface CosmosDBTriggerBinding_V4<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
-  /**
-   * Required - Must be set to `cosmosDBTrigger`.
-   */
-  type: CosmosDBTriggerType;
-
-  direction: 'in';
-  /**
-   * The name of the Azure Cosmos DB database with the collection being monitored.
-   */
-  databaseName: string;
+export interface CosmosDBTriggerBinding_V4<Name> extends CosmosDBTriggerBinding_Base<Name> {
   /**
    * The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see [Connections](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#connections).
    */
@@ -128,10 +130,6 @@ export interface CosmosDBTriggerBinding_V4<Name> extends BaseFunctionBinding<Cos
   */
   leaseConnection?: any;
   /** 
-  (Optional) The name of the database that holds the container used to store leases. When not set, the value of the databaseName setting is used.
-  */
-  leaseDatabaseName?: any;
-  /** 
   (Optional) The name of the container used to store leases. When not set, the value leases is used.
   */
   leaseContainerName?: any;
@@ -147,175 +145,4 @@ export interface CosmosDBTriggerBinding_V4<Name> extends BaseFunctionBinding<Cos
   (Optional) When set, the value is added as a prefix to the leases created in the Lease container for this function. Using a prefix allows two separate Azure Functions to share the same Lease container by using different prefixes.
   */
   leaseContainerPrefix?: any;
-  /** 
-  (Optional) The time (in milliseconds) for the delay between polling a partition for new changes on the feed, after all current changes are drained. Default is 5,000 milliseconds, or 5 seconds.
-  */
-  feedPollDelay?: any;
-  /** 
-  (Optional) When set, it defines, in milliseconds, the interval to kick off a task to compute if partitions are distributed evenly among known host instances. Default is 13000 (13 seconds).
-  */
-  leaseAcquireInterval?: any;
-  /** 
-  (Optional) When set, it defines, in milliseconds, the interval for which the lease is taken on a lease representing a partition. If the lease is not renewed within this interval, it will cause it to expire and ownership of the partition will move to another instance. Default is 60000 (60 seconds).
-  */
-  leaseExpirationInterval?: any;
-}
-
-/**
- * Azure Functions Cosmos DB Type
- */
-export type CosmosDBType = 'cosmosDB';
-
-export interface CosmosDBBinding_Output_V2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
-  /**
-   * Required - Must be set to `cosmosDB`.
-   */
-  type: CosmosDBType;
-
-  direction: 'out';
-  /**
-   * The name of the Azure Cosmos DB database with the collection being monitored.
-   */
-  databaseName: string;
-  /** 
-  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
-  */
-  connectionStringSetting?: string;
-  /** 
-  The name of the collection being monitored.
-  */
-  collectionName: string;
-  /** 
-  A boolean value to indicate whether the collection is created when it doesn't exist. The default is false because new collections are created with reserved throughput, which has cost implications. For more information, see the pricing page.
-  */
-  createIfNotExists: boolean;
-  /** 
-  When createIfNotExists is true, it defines the partition key path for the created collection. May include binding parameters.
-  */
-  partitionKey: string;
-  /** 
-  When createIfNotExists is true, it defines the throughput of the created collection.
-  */
-  collectionThroughput?: any;
-  /** 
-  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
-  */
-  preferredLocations?: any;
-  /** 
-  (Optional) When set to true along with preferredLocations, supports multi-region writes in the Azure Cosmos DB service.
-  */
-  useMultipleWriteLocations?: any;
-}
-
-export interface CosmosDBBinding_Output_V4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
-  /**
-   * Required - Must be set to `cosmosDB`.
-   */
-  type: CosmosDBType;
-
-  direction: 'out';
-  /**
-   * The name of the Azure Cosmos DB database with the collection being monitored.
-   */
-  databaseName: string;
-  /** 
-  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
-  */
-  connection?: string;
-  /** 
-  The name of the container being monitored.
-  */
-  containerName?: string;
-  /** 
-  A boolean value to indicate whether the container is created when it doesn't exist. The default is false because new containers are created with reserved throughput, which has cost implications. For more information, see the pricing page.
-  */
-  createIfNotExists?: boolean;
-  /** 
-  When createIfNotExists is true, it defines the partition key path for the created container. May include binding parameters.
-  */
-  partitionKey?: string;
-  /** 
-  When createIfNotExists is true, it defines the throughput of the created container.
-  */
-  containerThroughput?: any;
-  /** 
-  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
-  */
-  preferredLocations?: any;
-}
-
-export interface CosmosDBBinding_Input_V2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
-  /**
-   * Required - Must be set to `cosmosDB`.
-   */
-  type: CosmosDBType;
-
-  direction: 'in';
-
-  /** 
-  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
-  */
-  connectionStringSetting: any;
-  /** 
-  The name of the Azure Cosmos DB database with the collection being monitored.
-  */
-  databaseName: any;
-  /** 
-  The name of the collection being monitored.
-  */
-  collectionName: any;
-  /** 
-  Specifies the partition key value for the lookup. May include binding parameters. It is required for lookups in partitioned collections.
-  */
-  partitionKey: any;
-  /** 
-  The ID of the document to retrieve. This property supports binding expressions. Don't set both the id and sqlQuery properties. If you don't set either one, the entire collection is retrieved.
-  */
-  id: any;
-  /** 
-  An Azure Cosmos DB SQL query used for retrieving multiple documents. The property supports runtime bindings, as in this example: SELECT * FROM c where c.departmentId = {departmentId}. Don't set both the id and sqlQuery properties. If you don't set either one, the entire collection is retrieved.
-  */
-  sqlQuery: any;
-  /** 
-  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
-  */
-  preferredLocations?: any;
-}
-
-export interface CosmosDBBinding_Input_V4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
-  /**
-   * Required - Must be set to `cosmosDB`.
-   */
-  type: CosmosDBType;
-
-  direction: 'in';
-
-  /** 
-  The name of an app setting or setting container that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
-  */
-  connection: any;
-  /** 
-  The name of the Azure Cosmos DB database with the container being monitored.
-  */
-  databaseName: any;
-  /** 
-  The name of the container being monitored.
-  */
-  containerName: any;
-  /** 
-  Specifies the partition key value for the lookup. May include binding parameters. It is required for lookups in partitioned containers.
-  */
-  partitionKey: any;
-  /** 
-  The ID of the document to retrieve. This property supports binding expressions. Don't set both the id and sqlQuery properties. If you don't set either one, the entire container is retrieved.
-  */
-  id: any;
-  /** 
-  An Azure Cosmos DB SQL query used for retrieving multiple documents. The property supports runtime bindings, as in this example: SELECT * FROM c where c.departmentId = {departmentId}. Don't set both the id and sqlQuery properties. If you don't set either one, the entire container is retrieved.
-  */
-  sqlQuery: any;
-  /** 
-  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
-  */
-  preferredLocations?: any;
 }

--- a/packages/core/src/bindings/interfaces/triggers/cosmos-db-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/cosmos-db-trigger.binding.ts
@@ -105,7 +105,7 @@ export interface CosmosDBTriggerBinding_v4<Name> extends BaseFunctionBinding<Cos
    * Required - Must be set to `cosmosDBTrigger`.
    */
   type: CosmosDBTriggerType;
-  
+
   direction: 'in';
   /**
    * The name of the Azure Cosmos DB database with the collection being monitored.
@@ -166,7 +166,7 @@ export interface CosmosDBTriggerBinding_v4<Name> extends BaseFunctionBinding<Cos
  */
 export type CosmosDBType = 'cosmosDB';
 
-export interface CosmosDBBinding_v2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+export interface CosmosDBBinding_Output_v2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
   /**
    * Required - Must be set to `cosmosDB`.
    */
@@ -207,7 +207,7 @@ export interface CosmosDBBinding_v2<Name> extends BaseFunctionBinding<CosmosDBTy
   useMultipleWriteLocations?: any;
 }
 
-export interface CosmosDBBinding_v4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+export interface CosmosDBBinding_Output_v4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
   /**
    * Required - Must be set to `cosmosDB`.
    */
@@ -238,6 +238,82 @@ export interface CosmosDBBinding_v4<Name> extends BaseFunctionBinding<CosmosDBTy
   When createIfNotExists is true, it defines the throughput of the created container.
   */
   containerThroughput?: any;
+  /** 
+  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
+  */
+  preferredLocations?: any;
+}
+
+export interface CosmosDBBinding_Input_v2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+  /**
+   * Required - Must be set to `cosmosDB`.
+   */
+  type: CosmosDBType;
+
+  direction: 'in';
+
+  /** 
+  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
+  */
+  connectionStringSetting: any;
+  /** 
+  The name of the Azure Cosmos DB database with the collection being monitored.
+  */
+  databaseName: any;
+  /** 
+  The name of the collection being monitored.
+  */
+  collectionName: any;
+  /** 
+  Specifies the partition key value for the lookup. May include binding parameters. It is required for lookups in partitioned collections.
+  */
+  partitionKey: any;
+  /** 
+  The ID of the document to retrieve. This property supports binding expressions. Don't set both the id and sqlQuery properties. If you don't set either one, the entire collection is retrieved.
+  */
+  id: any;
+  /** 
+  An Azure Cosmos DB SQL query used for retrieving multiple documents. The property supports runtime bindings, as in this example: SELECT * FROM c where c.departmentId = {departmentId}. Don't set both the id and sqlQuery properties. If you don't set either one, the entire collection is retrieved.
+  */
+  sqlQuery: any;
+  /** 
+  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
+  */
+  preferredLocations?: any;
+}
+
+export interface CosmosDBBinding_Input_v4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+  /**
+   * Required - Must be set to `cosmosDB`.
+   */
+  type: CosmosDBType;
+
+  direction: 'in';
+
+  /** 
+  The name of an app setting or setting container that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
+  */
+  connection: any;
+  /** 
+  The name of the Azure Cosmos DB database with the container being monitored.
+  */
+  databaseName: any;
+  /** 
+  The name of the container being monitored.
+  */
+  containerName: any;
+  /** 
+  Specifies the partition key value for the lookup. May include binding parameters. It is required for lookups in partitioned containers.
+  */
+  partitionKey: any;
+  /** 
+  The ID of the document to retrieve. This property supports binding expressions. Don't set both the id and sqlQuery properties. If you don't set either one, the entire container is retrieved.
+  */
+  id: any;
+  /** 
+  An Azure Cosmos DB SQL query used for retrieving multiple documents. The property supports runtime bindings, as in this example: SELECT * FROM c where c.departmentId = {departmentId}. Don't set both the id and sqlQuery properties. If you don't set either one, the entire container is retrieved.
+  */
+  sqlQuery: any;
   /** 
   (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
   */

--- a/packages/core/src/bindings/interfaces/triggers/cosmos-db-trigger.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/cosmos-db-trigger.binding.ts
@@ -9,7 +9,7 @@ export type CosmosDBTriggerType = 'cosmosDBTrigger';
  * CosmosDBTrigger Type v2 with [cosmosDBTrigger Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
  */
 
-export interface CosmosDBTriggerBinding_v2<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
+export interface CosmosDBTriggerBinding_V2<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
   /**
    * Required - Must be set to `cosmosDBTrigger`.
    */
@@ -100,7 +100,7 @@ export interface CosmosDBTriggerBinding_v2<Name> extends BaseFunctionBinding<Cos
 /**
  * CosmosDBTrigger Type v4 with [cosmosDBTrigger Type](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-trigger?tabs=in-process%2Cextensionv4&pivots=programming-language-javascript#configuration)
  */
-export interface CosmosDBTriggerBinding_v4<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
+export interface CosmosDBTriggerBinding_V4<Name> extends BaseFunctionBinding<CosmosDBTriggerType, Name> {
   /**
    * Required - Must be set to `cosmosDBTrigger`.
    */
@@ -166,7 +166,7 @@ export interface CosmosDBTriggerBinding_v4<Name> extends BaseFunctionBinding<Cos
  */
 export type CosmosDBType = 'cosmosDB';
 
-export interface CosmosDBBinding_Output_v2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+export interface CosmosDBBinding_Output_V2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
   /**
    * Required - Must be set to `cosmosDB`.
    */
@@ -207,7 +207,7 @@ export interface CosmosDBBinding_Output_v2<Name> extends BaseFunctionBinding<Cos
   useMultipleWriteLocations?: any;
 }
 
-export interface CosmosDBBinding_Output_v4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+export interface CosmosDBBinding_Output_V4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
   /**
    * Required - Must be set to `cosmosDB`.
    */
@@ -244,7 +244,7 @@ export interface CosmosDBBinding_Output_v4<Name> extends BaseFunctionBinding<Cos
   preferredLocations?: any;
 }
 
-export interface CosmosDBBinding_Input_v2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+export interface CosmosDBBinding_Input_V2<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
   /**
    * Required - Must be set to `cosmosDB`.
    */
@@ -282,7 +282,7 @@ export interface CosmosDBBinding_Input_v2<Name> extends BaseFunctionBinding<Cosm
   preferredLocations?: any;
 }
 
-export interface CosmosDBBinding_Input_v4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+export interface CosmosDBBinding_Input_V4<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
   /**
    * Required - Must be set to `cosmosDB`.
    */

--- a/packages/core/src/bindings/interfaces/triggers/cosmos-db.binding.ts
+++ b/packages/core/src/bindings/interfaces/triggers/cosmos-db.binding.ts
@@ -1,0 +1,106 @@
+import { BaseFunctionBinding } from '../base-function-binding';
+
+/**
+ * Azure Functions Cosmos DB Type
+ */
+export type CosmosDBType = 'cosmosDB';
+
+interface CosmosDBBinding_Base<Name> extends BaseFunctionBinding<CosmosDBType, Name> {
+  /**
+   * Required - Must be set to `cosmosDB`.
+   */
+  type: CosmosDBType;
+ /**
+   * The name of the Azure Cosmos DB database with the collection being monitored.
+   */
+    databaseName: string;
+  /** 
+  (Optional) Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service. Values should be comma-separated. For example, East US,South Central US,North Europe.
+  */
+  preferredLocations?: any;
+}
+
+interface CosmosDBBinding_Output_Base<Name> extends CosmosDBBinding_Base<Name> {
+  direction: 'out';
+
+  /** 
+  A boolean value to indicate whether the collection is created when it doesn't exist. The default is false because new collections are created with reserved throughput, which has cost implications. For more information, see the pricing page.
+  */
+  createIfNotExists: boolean;
+  /** 
+  When createIfNotExists is true, it defines the partition key path for the created collection. May include binding parameters.
+  */
+  partitionKey?: string;
+}
+
+export interface CosmosDBBinding_Output_V2<Name> extends CosmosDBBinding_Output_Base<Name> {
+  /** 
+  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
+  */
+  connectionStringSetting: string;
+  /** 
+  The name of the collection being monitored.
+  */
+  collectionName: string;
+  /** 
+  When createIfNotExists is true, it defines the throughput of the created collection.
+  */
+  collectionThroughput?: any;
+  /** 
+  (Optional) When set to true along with preferredLocations, supports multi-region writes in the Azure Cosmos DB service.
+  */
+  useMultipleWriteLocations?: any;
+}
+
+export interface CosmosDBBinding_Output_V4<Name> extends CosmosDBBinding_Output_Base<Name> {
+  /** 
+  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
+  */
+  connection: string;
+  /** 
+  The name of the container being monitored.
+  */
+  containerName: string;
+  /** 
+  When createIfNotExists is true, it defines the throughput of the created container.
+  */
+  containerThroughput?: any;
+}
+
+export interface CosmosDBBinding_Input_Base<Name> extends CosmosDBBinding_Base<Name> {
+  direction: 'in';
+  /** 
+  Specifies the partition key value for the lookup. May include binding parameters. It is required for lookups in partitioned collections.
+  */
+  partitionKey: string;
+  /** 
+  The ID of the document to retrieve. This property supports binding expressions. Don't set both the id and sqlQuery properties. If you don't set either one, the entire collection is retrieved.
+  */
+  id: any;
+  /** 
+  An Azure Cosmos DB SQL query used for retrieving multiple documents. The property supports runtime bindings, as in this example: SELECT * FROM c where c.departmentId = {departmentId}. Don't set both the id and sqlQuery properties. If you don't set either one, the entire collection is retrieved.
+  */
+  sqlQuery: string;
+}
+
+export interface CosmosDBBinding_Input_V2<Name> extends CosmosDBBinding_Input_Base<Name> {
+  /** 
+  The name of an app setting or setting collection that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
+  */
+  connectionStringSetting: string;
+  /** 
+  The name of the collection being monitored.
+  */
+  collectionName: string;
+}
+
+export interface CosmosDBBinding_Input_V4<Name> extends CosmosDBBinding_Input_Base<Name> {
+  /** 
+  The name of an app setting or setting container that specifies how to connect to the Azure Cosmos DB account being monitored. For more information, see Connections.
+  */
+  connection: string;
+  /** 
+  The name of the container being monitored.
+  */
+  containerName: string;
+}

--- a/packages/core/src/bindings/interfaces/triggers/index.ts
+++ b/packages/core/src/bindings/interfaces/triggers/index.ts
@@ -1,3 +1,4 @@
 export * from './http-trigger.binding';
 export * from './timer-trigger.binding';
 export * from './cosmos-db-trigger.binding';
+export * from './cosmos-db.binding';

--- a/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
+++ b/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
@@ -5,7 +5,7 @@ import { HttpRequest, HttpResponse, Timer} from '@azure/functions';
 const bindings = [
   Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
   Binding.http({ name: 'res' as const }), // make string to literal type
-  Binding.httpWithReturn(),
+  Binding.http_withReturn(),
   Binding.timerTrigger({ name: 'timer' as const, schedule: '*' }), // make string to literal type
   Binding.cosmosDBTrigger_v2({
     name: 'document_input_v2',
@@ -27,20 +27,20 @@ const bindings = [
     containerName: '',
     databaseName: '',
   }),
-  Binding.cosmosDB_v2({
+  Binding.cosmosDB_output_v2({
     name: 'document_output_v2' as const,
     collectionName: '',
     createIfNotExists: true,
     databaseName: '',
     partitionKey: ''
   }),
-  Binding.cosmosDB_v4({
+  Binding.cosmosDB_output_v4({
     name: 'document_output_v4' as const,
     connection: '',
     containerName: '',
     databaseName: '',
   }),
-  Binding.cosmosDB({
+  Binding.cosmosDB_output({
     name: 'document_output_default' as const,
     connection: '',
     containerName: '',

--- a/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
+++ b/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
@@ -1,6 +1,6 @@
 import { BaseFunction, Binding, functionName } from '../../../../main';
 import { responseHelper } from '../../../response-helper';
-import { HttpRequest, HttpResponse, Timer} from '@azure/functions';
+import { HttpRequest, HttpResponse, Timer } from '@azure/functions';
 
 const bindings = [
   Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
@@ -8,7 +8,7 @@ const bindings = [
   Binding.http_withReturn(),
   Binding.timerTrigger({ name: 'timer' as const, schedule: '*' }), // make string to literal type
   Binding.cosmosDBTrigger_v2({
-    name: 'document_input_v2',
+    name: 'document_trigger_v2' as const,
     collectionName: '',
     connection: '',
     connectionStringSetting: '',
@@ -16,13 +16,13 @@ const bindings = [
     databaseName: '',
   }),
   Binding.cosmosDBTrigger_v4({
-    name: 'document_input_v4' as const,
+    name: 'document_trigger_v4' as const,
     connection: '',
     containerName: '',
     databaseName: '',
   }),
   Binding.cosmosDBTrigger({
-    name: 'document_input_default' as const,
+    name: 'document_trigger_default' as const,
     connection: '',
     containerName: '',
     databaseName: '',
@@ -32,21 +32,48 @@ const bindings = [
     collectionName: '',
     connectionStringSetting: '',
     createIfNotExists: true,
-    databaseName: ''
+    databaseName: '',
   }),
   Binding.cosmosDB_output_v4({
     name: 'document_output_v4' as const,
     createIfNotExists: true,
     databaseName: '',
     connection: '',
-    containerName: ''
+    containerName: '',
   }),
   Binding.cosmosDB_output({
     name: 'document_output_default' as const,
     createIfNotExists: true,
     databaseName: '',
     connection: '',
-    containerName: ''
+    containerName: '',
+  }),
+  Binding.cosmosDB_input_v2({
+    name: 'document_input_v2' as const,
+    collectionName: '',
+    connectionStringSetting: '',
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+  }),
+  Binding.cosmosDB_input_v4({
+    name: 'document_input_v4' as const,
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+    connection: '',
+    containerName: '',
+  }),
+  Binding.cosmosDB_input({
+    name: 'document_input_default' as const,
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+    connection: '',
+    containerName: '',
   }),
 ] as const;
 
@@ -58,12 +85,19 @@ export class AllBindingsFunction extends BaseFunction<typeof bindings> {
     const req: HttpRequest = this.bindings.req;
     const res: HttpResponse = this.bindings.res;
     const timer: Timer = this.bindings.timer;
-    const document_input_v2: any = this.bindings.document_input_v2;
+
     const document_output_v2: any = this.bindings.document_output_v2;
-    const document_input_v4: any = this.bindings.document_input_v4;
     const document_output_v4: any = this.bindings.document_output_v4;
-    const document_input_default: any = this.bindings.document_input_default;
     const document_output_default: any = this.bindings.document_output_default;
+
+    const document_input_v2: any = this.bindings.document_input_v2;
+    const document_input_v4: any = this.bindings.document_input_v4;
+    const document_input_default: any = this.bindings.document_input_default;
+
+    const document_trigger_v2: any = this.bindings.document_trigger_v2;
+    const document_trigger_v4: any = this.bindings.document_trigger_v4;
+    const document_trigger_default: any = this.bindings.document_trigger_default;
+
     const { name } = this.req.query;
     this.res.send(responseHelper(name));
   }

--- a/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
+++ b/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
@@ -30,21 +30,23 @@ const bindings = [
   Binding.cosmosDB_output_v2({
     name: 'document_output_v2' as const,
     collectionName: '',
+    connectionStringSetting: '',
     createIfNotExists: true,
-    databaseName: '',
-    partitionKey: ''
+    databaseName: ''
   }),
   Binding.cosmosDB_output_v4({
     name: 'document_output_v4' as const,
-    connection: '',
-    containerName: '',
+    createIfNotExists: true,
     databaseName: '',
+    connection: '',
+    containerName: ''
   }),
   Binding.cosmosDB_output({
     name: 'document_output_default' as const,
-    connection: '',
-    containerName: '',
+    createIfNotExists: true,
     databaseName: '',
+    connection: '',
+    containerName: ''
   }),
 ] as const;
 


### PR DESCRIPTION
Correct type of Cosmos DB Binding Input (Confuse in Official Documentation)

## Rename `Binding.httpWithReturn()`

rename to `Binding.http_withReturn()` for consistency convention name

## Update all cosmosDB binding helper functions:

```ts
const bindings = [
  Binding.cosmosDBTrigger_v2({
    name: 'document_trigger_v2'  as const,
    collectionName: '',
    connection: '',
    connectionStringSetting: '',
    containerName: '',
    databaseName: '',
  }),
  Binding.cosmosDBTrigger_v4({
    name: 'document_trigger_v4' as const,
    connection: '',
    containerName: '',
    databaseName: '',
  }),
  Binding.cosmosDBTrigger({
    name: 'document_trigger_default' as const,
    connection: '',
    containerName: '',
    databaseName: '',
  }),
  Binding.cosmosDB_output_v2({
    name: 'document_output_v2' as const,
    collectionName: '',
    connectionStringSetting: '',
    createIfNotExists: true,
    databaseName: '',
  }),
  Binding.cosmosDB_output_v4({
    name: 'document_output_v4' as const,
    createIfNotExists: true,
    databaseName: '',
    connection: '',
    containerName: '',
  }),
  Binding.cosmosDB_output({
    name: 'document_output_default' as const,
    createIfNotExists: true,
    databaseName: '',
    connection: '',
    containerName: '',
  }),
  Binding.cosmosDB_input_v2({
    name: 'document_input_v2' as const,
    collectionName: '',
    connectionStringSetting: '',
    databaseName: '',
    id: '',
    partitionKey: '',
    sqlQuery: '',
  }),
  Binding.cosmosDB_input_v4({
    name: 'document_input_v4' as const,
    databaseName: '',
    id: '',
    partitionKey: '',
    sqlQuery: '',
    connection: '',
    containerName: '',
  }),
  Binding.cosmosDB_input({
    name: 'document_input_default' as const,
    databaseName: '',
    id: '',
    partitionKey: '',
    sqlQuery: '',
    connection: '',
    containerName: '',
  }),
] as const;
```