### PR TITLE
feat: infer input, output return from binding type

### DIFF
--- a/examples/basic/src/functions/with-type-utility.controller.ts
+++ b/examples/basic/src/functions/with-type-utility.controller.ts
@@ -2,16 +2,10 @@ import { inject } from 'inversify';
 import { binding, BaseFunction, functionName } from 'nammatham';
 import { Service } from './services';
 
-/**
- * remove
- *
- * - binding.AuthorizationLevel
- */
 const bindings = [
   binding.httpTrigger({ name: 'req' as const }), // make string to literal type
   binding.http({ name: 'res' as const }), // make string to literal type
 ] as const;
-
 
 @functionName('WithTypeUtility', ...bindings)
 export class WithTypeUtilityFunction extends BaseFunction<typeof bindings> {

--- a/packages/core/src/bindings/index.ts
+++ b/packages/core/src/bindings/index.ts
@@ -1,3 +1,9 @@
 export * from './interfaces';
 export * from './types';
 export * from './binding';
+
+import type { GetBindings, GetOnlyOutputBindings, GetOnlyInputBindings, GetOnlyReturnBindings } from './types';
+export type { GetBindings as infer };
+export type { GetOnlyOutputBindings as inferOutput };
+export type { GetOnlyInputBindings as inferInput };
+export type { GetOnlyReturnBindings as inferReturn };

--- a/packages/core/src/bindings/types/binding.ts
+++ b/packages/core/src/bindings/types/binding.ts
@@ -3,10 +3,6 @@ import { FunctionBinding } from '../interfaces/function-binding';
 import { HttpRequest, HttpResponse, Timer } from '@azure/functions';
 
 export type AllBindingTypes = FunctionBinding<unknown>['type'];
-/**
- * Only trigger with direction `in`
- */
-export type AllBindingInputTypes = Exclude<AllBindingTypes, HttpType>;
 
 export type BindingType<T extends AllBindingTypes> = T extends HttpTriggerType
   ? HttpRequest

--- a/packages/core/src/bindings/types/get-context-bindings.d-test.ts
+++ b/packages/core/src/bindings/types/get-context-bindings.d-test.ts
@@ -1,5 +1,10 @@
 import type { Equal, Expect } from '@type-challenges/utils';
-import { GetBindings } from './get-context-bindings';
+import {
+  GetBindings,
+  GetOnlyInputBindings,
+  GetOnlyReturnBindings,
+  GetOnlyOutputBindings,
+} from './get-context-bindings';
 import { ContextBindings, HttpRequest, HttpResponse, Timer } from '@azure/functions';
 import { HttpBinding, TimerTriggerBinding, HttpTriggerBinding } from '../interfaces';
 
@@ -26,14 +31,29 @@ const bindings = [
   } as TimerTriggerBinding<'timer'>,
 ] as const;
 
-type ExpectedType = ContextBindings &
+type ExpectedType_AllBindings = ContextBindings &
   // Expected map name with Azure Functions Type
   Record<'req', HttpRequest> &
   Record<'res', HttpResponse> &
   Record<'$return', HttpResponse> & // Duplicate type still work!
   Record<'timer', Timer>;
 
-type Cases = [ 
+type ExpectedType_OnlyInputBindings = ContextBindings &
+  // Expected map name with Azure Functions Type
+  Record<'req', HttpRequest> &
+  Record<'timer', Timer>;
+
+type ExpectedType_OnlyOutputBindings = ContextBindings &
+  // Expected map name with Azure Functions Type
+  Record<'res', HttpResponse> &
+  Record<'$return', HttpResponse>;
+
+type ExpectedType_OnlyReturnBindings = HttpResponse;
+
+type Cases = [
   // Test all cases
-  Expect<Equal<GetBindings<typeof bindings>, ExpectedType>>
+  Expect<Equal<GetBindings<typeof bindings>, ExpectedType_AllBindings>>,
+  Expect<Equal<GetOnlyInputBindings<typeof bindings>, ExpectedType_OnlyInputBindings>>,
+  Expect<Equal<GetOnlyOutputBindings<typeof bindings>, ExpectedType_OnlyOutputBindings>>,
+  Expect<Equal<GetOnlyReturnBindings<typeof bindings>, ExpectedType_OnlyReturnBindings>>
 ];

--- a/packages/core/src/bindings/types/get-context-bindings.ts
+++ b/packages/core/src/bindings/types/get-context-bindings.ts
@@ -2,6 +2,7 @@ import { ContextBindings } from '@azure/functions';
 import { FunctionBinding } from '../interfaces/function-binding';
 import { BindingType } from './binding';
 import { Zipper } from '../../types';
+import { Binding, DirectionType } from '../../main';
 
 type GetTypeTuple<T extends readonly FunctionBinding<unknown>[]> = T extends readonly [infer Head, ...infer Tail]
   ? Head extends FunctionBinding<unknown>
@@ -19,8 +20,101 @@ type GetNameTuple<T extends readonly FunctionBinding<unknown>[]> = T extends rea
     : []
   : [];
 
+const bindings = [
+  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
+  Binding.http({ name: 'res' as const }), // make string to literal type
+  Binding.http_withReturn(),
+  Binding.timerTrigger({ name: 'timer' as const, schedule: '*' }), // make string to literal type
+  Binding.cosmosDBTrigger_v2({
+    name: 'document_trigger_v2' as const,
+    collectionName: '',
+    connection: '',
+    connectionStringSetting: '',
+    containerName: '',
+    databaseName: '',
+  }),
+  Binding.cosmosDBTrigger_v4({
+    name: 'document_trigger_v4' as const,
+    connection: '',
+    containerName: '',
+    databaseName: '',
+  }),
+  Binding.cosmosDBTrigger({
+    name: 'document_trigger_default' as const,
+    connection: '',
+    containerName: '',
+    databaseName: '',
+  }),
+  Binding.cosmosDB_output_v2({
+    name: 'document_output_v2' as const,
+    collectionName: '',
+    connectionStringSetting: '',
+    createIfNotExists: true,
+    databaseName: '',
+  }),
+  Binding.cosmosDB_output_v4({
+    name: 'document_output_v4' as const,
+    createIfNotExists: true,
+    databaseName: '',
+    connection: '',
+    containerName: '',
+  }),
+  Binding.cosmosDB_output({
+    name: 'document_output_default' as const,
+    createIfNotExists: true,
+    databaseName: '',
+    connection: '',
+    containerName: '',
+  }),
+  Binding.cosmosDB_input_v2({
+    name: 'document_input_v2' as const,
+    collectionName: '',
+    connectionStringSetting: '',
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+  }),
+  Binding.cosmosDB_input_v4({
+    name: 'document_input_v4' as const,
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+    connection: '',
+    containerName: '',
+  }),
+  Binding.cosmosDB_input({
+    name: 'document_input_default' as const,
+    databaseName: '',
+    id: '',
+    partitionKey: '',
+    sqlQuery: '',
+    connection: '',
+    containerName: '',
+  }),
+] as const;
+
+type FilterBindingsDirection<T extends readonly FunctionBinding<unknown>[], Direction extends DirectionType> = T extends readonly [
+  infer Head,
+  ...infer Tail
+]
+  ? Head extends FunctionBinding<unknown>
+    ? Tail extends FunctionBinding<unknown>[]
+      ? Head['direction'] extends Direction
+        ? [Head, ...FilterBindingsDirection<Tail, Direction>]
+        : [...FilterBindingsDirection<Tail, Direction>]
+      : []
+    : []
+  : [];
+
+type A = FilterBindingsDirection<typeof bindings, 'out'>;
+  // ^?
 /**
  * `GetBindings`, extract type from `FunctionBinding<unknown>[]`
  */
 export type GetBindings<T extends readonly FunctionBinding<unknown>[]> = ContextBindings &
   Zipper<GetNameTuple<T>, GetTypeTuple<T>>;
+
+type B = GetBindings<FilterBindingsDirection<typeof bindings, 'out'>>;
+  // ^?

--- a/packages/core/src/bindings/types/get-context-bindings.ts
+++ b/packages/core/src/bindings/types/get-context-bindings.ts
@@ -2,7 +2,7 @@ import { ContextBindings } from '@azure/functions';
 import { FunctionBinding } from '../interfaces/function-binding';
 import { BindingType } from './binding';
 import { Zipper } from '../../types';
-import { Binding, DirectionType } from '../../main';
+import { DirectionType } from '../../main';
 
 type GetTypeTuple<T extends readonly FunctionBinding<unknown>[]> = T extends readonly [infer Head, ...infer Tail]
   ? Head extends FunctionBinding<unknown>
@@ -20,85 +20,10 @@ type GetNameTuple<T extends readonly FunctionBinding<unknown>[]> = T extends rea
     : []
   : [];
 
-const bindings = [
-  Binding.httpTrigger({ name: 'req' as const }), // make string to literal type
-  Binding.http({ name: 'res' as const }), // make string to literal type
-  Binding.http_withReturn(),
-  Binding.timerTrigger({ name: 'timer' as const, schedule: '*' }), // make string to literal type
-  Binding.cosmosDBTrigger_v2({
-    name: 'document_trigger_v2' as const,
-    collectionName: '',
-    connection: '',
-    connectionStringSetting: '',
-    containerName: '',
-    databaseName: '',
-  }),
-  Binding.cosmosDBTrigger_v4({
-    name: 'document_trigger_v4' as const,
-    connection: '',
-    containerName: '',
-    databaseName: '',
-  }),
-  Binding.cosmosDBTrigger({
-    name: 'document_trigger_default' as const,
-    connection: '',
-    containerName: '',
-    databaseName: '',
-  }),
-  Binding.cosmosDB_output_v2({
-    name: 'document_output_v2' as const,
-    collectionName: '',
-    connectionStringSetting: '',
-    createIfNotExists: true,
-    databaseName: '',
-  }),
-  Binding.cosmosDB_output_v4({
-    name: 'document_output_v4' as const,
-    createIfNotExists: true,
-    databaseName: '',
-    connection: '',
-    containerName: '',
-  }),
-  Binding.cosmosDB_output({
-    name: 'document_output_default' as const,
-    createIfNotExists: true,
-    databaseName: '',
-    connection: '',
-    containerName: '',
-  }),
-  Binding.cosmosDB_input_v2({
-    name: 'document_input_v2' as const,
-    collectionName: '',
-    connectionStringSetting: '',
-    databaseName: '',
-    id: '',
-    partitionKey: '',
-    sqlQuery: '',
-  }),
-  Binding.cosmosDB_input_v4({
-    name: 'document_input_v4' as const,
-    databaseName: '',
-    id: '',
-    partitionKey: '',
-    sqlQuery: '',
-    connection: '',
-    containerName: '',
-  }),
-  Binding.cosmosDB_input({
-    name: 'document_input_default' as const,
-    databaseName: '',
-    id: '',
-    partitionKey: '',
-    sqlQuery: '',
-    connection: '',
-    containerName: '',
-  }),
-] as const;
-
-type FilterBindingsDirection<T extends readonly FunctionBinding<unknown>[], Direction extends DirectionType> = T extends readonly [
-  infer Head,
-  ...infer Tail
-]
+type FilterBindingsDirection<
+  T extends readonly FunctionBinding<unknown>[],
+  Direction extends DirectionType
+> = T extends readonly [infer Head, ...infer Tail]
   ? Head extends FunctionBinding<unknown>
     ? Tail extends FunctionBinding<unknown>[]
       ? Head['direction'] extends Direction
@@ -108,13 +33,56 @@ type FilterBindingsDirection<T extends readonly FunctionBinding<unknown>[], Dire
     : []
   : [];
 
-type A = FilterBindingsDirection<typeof bindings, 'out'>;
-  // ^?
 /**
  * `GetBindings`, extract type from `FunctionBinding<unknown>[]`
  */
 export type GetBindings<T extends readonly FunctionBinding<unknown>[]> = ContextBindings &
   Zipper<GetNameTuple<T>, GetTypeTuple<T>>;
 
-type B = GetBindings<FilterBindingsDirection<typeof bindings, 'out'>>;
-  // ^?
+export type GetOnlyOutputBindings<T extends readonly FunctionBinding<unknown>[]> = GetBindings<
+  FilterBindingsDirection<T, 'out'>
+>;
+export type GetOnlyInputBindings<T extends readonly FunctionBinding<unknown>[]> = GetBindings<
+  FilterBindingsDirection<T, 'in'>
+>;
+export type GetOnlyInputOutputBindings<T extends readonly FunctionBinding<unknown>[]> = GetBindings<
+  FilterBindingsDirection<T, 'inout'>
+>;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+type GetBindingOnlyReturnName<T extends readonly FunctionBinding<unknown>[]> = T extends readonly [
+  infer Head,
+  ...infer Tail
+]
+  ? Head extends FunctionBinding<unknown>
+    ? Tail extends FunctionBinding<unknown>[]
+      ? Head['name'] extends '$return'
+        ? [Head]
+        : [...GetBindingOnlyReturnName<Tail>]
+      : []
+    : []
+  : [];
+
+type GetFirstArray<T extends any[]> = T['length'] extends 1 ? T[0] : undefined;
+
+/**
+ * Get Correct Type from Return Functions,
+ *
+ * If set the `name` property in function.json to `$return`, it will return only single output.
+ * Otherwise, it will return multiple output.
+ *
+ * Set the `name` property in function.json to `$return`. If there are multiple output bindings, use the return value for only one of them.
+ * Ref: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-return-value?tabs=javascript
+ */
+
+export type GetOnlyReturnBindings<T extends readonly FunctionBinding<unknown>[]> = GetFirstArray<
+  GetBindingOnlyReturnName<T>
+> extends infer Item
+  ? Item extends undefined
+    ? GetOnlyOutputBindings<T>
+    : Item extends FunctionBinding<unknown>
+    ? BindingType<Item['type']>
+    : never
+  : never;


### PR DESCRIPTION
## Add more utility types

```ts
binding.inferReturn<typeof bindings> // get return bindings
binding.inferOutput<typeof bindings> // get all output bindings
binding.inferInput<typeof bindings> // get all input bindings
binding.infer<typeof bindings> // get all bindings
```


## Example

```ts
import { BaseFunction, binding, functionName } from 'nammatham';

const bindings = [
  binding.httpTrigger({ name: 'req' as const}),
  binding.http({ name: 'res' as const }),
] as const;


@functionName('WithTypeUtility', ...bindings)
export class WithTypeUtilityFunction extends BaseFunction<typeof bindings> {

  public override execute(): binding.inferReturn<typeof bindings> {
    const { name } = this.req.query;
    return {
      res: this.res.send()
    }
  }
}
```