### PR TITLE
Improve binding helper inline doc of each property

### DIFF
--- a/packages/core/src/bindings/binding/cosmos-db-trigger.ts
+++ b/packages/core/src/bindings/binding/cosmos-db-trigger.ts
@@ -43,9 +43,9 @@ import {
  * @param bindings - `CosmosDBTriggerBinding_V4`
  * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
-export function cosmosDBTrigger_v2<T extends PartialBy<CosmosDBTriggerBinding_V2<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): CosmosDBTriggerBinding_V2<T['name']> {
+export function cosmosDBTrigger_v2<Binding extends CosmosDBTriggerBinding_V2<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBTriggerBinding_V2<Name>, 'type' | 'direction'>
+): CosmosDBTriggerBinding_V2<Name> {
   return {
     ...bindings,
     type: 'cosmosDBTrigger',
@@ -88,9 +88,9 @@ export function cosmosDBTrigger_v2<T extends PartialBy<CosmosDBTriggerBinding_V2
  * @param bindings - `CosmosDBTriggerBinding_V4`
  * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
-export function cosmosDBTrigger_v4<T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): CosmosDBTriggerBinding_V4<T['name']> {
+export function cosmosDBTrigger_v4<Binding extends CosmosDBTriggerBinding_V4<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBTriggerBinding_V4<Name>, 'type' | 'direction'>
+): CosmosDBTriggerBinding_V4<Name> {
   return {
     ...bindings,
     type: 'cosmosDBTrigger',
@@ -133,9 +133,15 @@ export function cosmosDBTrigger_v4<T extends PartialBy<CosmosDBTriggerBinding_V4
  * @param bindings - `CosmosDBTriggerBinding_V4`
  * @returns `CosmosDBTriggerBinding_V4` Object with `{ type: 'cosmosDBTrigger', direction: 'in' }`
  */
-export function cosmosDBTrigger<T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>>(
-  bindings: T
-) {
+// export function cosmosDBTrigger<T extends PartialBy<CosmosDBTriggerBinding_V4<unknown>, 'type' | 'direction'>>(
+//   bindings: T
+// ) {
+//   return cosmosDBTrigger_v4(bindings);
+// }
+
+export function cosmosDBTrigger<Binding extends CosmosDBTriggerBinding_V4<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBTriggerBinding_V4<Name>, 'type' | 'direction'>
+): CosmosDBTriggerBinding_V4<Name> {
   return cosmosDBTrigger_v4(bindings);
 }
 
@@ -174,9 +180,9 @@ export function cosmosDBTrigger<T extends PartialBy<CosmosDBTriggerBinding_V4<un
  * @param bindings - `CosmosDBBinding_Output_V2`
  * @returns `CosmosDBBinding_Output_V2` Object with `{ type: 'cosmosDB', direction: 'out' }`
  */
-export function cosmosDB_output_v2<T extends PartialBy<CosmosDBBinding_Output_V2<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): CosmosDBBinding_Output_V2<T['name']> {
+export function cosmosDB_output_v2<Binding extends CosmosDBBinding_Output_V2<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBBinding_Output_V2<Name>, 'type' | 'direction'>
+): CosmosDBBinding_Output_V2<Name> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -219,9 +225,9 @@ export function cosmosDB_output_v2<T extends PartialBy<CosmosDBBinding_Output_V2
   * @param bindings - `CosmosDBBinding_Output_V4`
   * @returns `CosmosDBBinding_Output_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
-export function cosmosDB_output_v4<T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): CosmosDBBinding_Output_V4<T['name']> {
+export function cosmosDB_output_v4<Binding extends CosmosDBBinding_Output_V4<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBBinding_Output_V4<Name>, 'type' | 'direction'>
+): CosmosDBBinding_Output_V4<Name> {
   return {
     ...bindings,
     type: 'cosmosDB',
@@ -264,9 +270,9 @@ export function cosmosDB_output_v4<T extends PartialBy<CosmosDBBinding_Output_V4
   * @param bindings - `CosmosDBBinding_Output_V4`
   * @returns `CosmosDBBinding_Output_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
   */
-export function cosmosDB_output<T extends PartialBy<CosmosDBBinding_Output_V4<unknown>, 'type' | 'direction'>>(
-  bindings: T
-) {
+export function cosmosDB_output<Binding extends CosmosDBBinding_Output_V4<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBBinding_Output_V4<Name>, 'type' | 'direction'>
+): CosmosDBBinding_Output_V4<Name> {
   return cosmosDB_output_v4(bindings);
 }
 
@@ -305,13 +311,13 @@ export function cosmosDB_output<T extends PartialBy<CosmosDBBinding_Output_V4<un
  * @param bindings - `CosmosDBBinding_Input_V2`
  * @returns `CosmosDBBinding_Input_V2` Object with `{ type: 'cosmosDB', direction: 'out' }`
  */
-export function cosmosDB_input_v2<T extends PartialBy<CosmosDBBinding_Input_V2<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): CosmosDBBinding_Input_V2<T['name']> {
+export function cosmosDB_input_v2<Binding extends CosmosDBBinding_Input_V2<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBBinding_Input_V2<Name>, 'type' | 'direction'>
+): CosmosDBBinding_Input_V2<Name> {
   return {
     ...bindings,
     type: 'cosmosDB',
-    direction: 'out',
+    direction: 'in',
   };
 }
 
@@ -350,13 +356,13 @@ export function cosmosDB_input_v2<T extends PartialBy<CosmosDBBinding_Input_V2<u
    * @param bindings - `CosmosDBBinding_Input_V4`
    * @returns `CosmosDBBinding_Input_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
    */
-export function cosmosDB_input_v4<T extends PartialBy<CosmosDBBinding_Input_V4<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): CosmosDBBinding_Input_V4<T['name']> {
+export function cosmosDB_input_v4<Binding extends CosmosDBBinding_Input_V4<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBBinding_Input_V4<Name>, 'type' | 'direction'>
+): CosmosDBBinding_Input_V4<Name> {
   return {
     ...bindings,
     type: 'cosmosDB',
-    direction: 'out',
+    direction: 'in',
   };
 }
 
@@ -395,8 +401,8 @@ export function cosmosDB_input_v4<T extends PartialBy<CosmosDBBinding_Input_V4<u
    * @param bindings - `CosmosDBBinding_Input_V4`
    * @returns `CosmosDBBinding_Input_V4` Object with `{ type: 'cosmosDB', direction: 'out' }`
    */
-export function cosmosDB_input<T extends PartialBy<CosmosDBBinding_Input_V4<unknown>, 'type' | 'direction'>>(
-  bindings: T
-) {
+export function cosmosDB_input<Binding extends CosmosDBBinding_Input_V4<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<CosmosDBBinding_Input_V4<Name>, 'type' | 'direction'>
+): CosmosDBBinding_Input_V4<Name> {
   return cosmosDB_input_v4(bindings);
 }

--- a/packages/core/src/bindings/binding/custom.ts
+++ b/packages/core/src/bindings/binding/custom.ts
@@ -28,6 +28,6 @@ import { CustomFunctionBinding } from '../interfaces';
  * @param bindings - `CustomFunctionBinding` Object
  * @returns `CustomFunctionBinding` Object
  */
-export function custom<T extends CustomFunctionBinding<unknown>>(bindings: T): CustomFunctionBinding<T['name']> {
+export function custom<Binding extends CustomFunctionBinding<unknown>>(bindings: Binding): CustomFunctionBinding<Binding['name']> {
   return bindings;
 }

--- a/packages/core/src/bindings/binding/http-trigger.ts
+++ b/packages/core/src/bindings/binding/http-trigger.ts
@@ -36,9 +36,9 @@ import { HttpTriggerBinding } from '../interfaces';
  * @param bindings - `HttpTriggerBinding`
  * @returns `HttpTriggerBinding` Object with `{ type: 'httpTrigger', direction: 'in' }`
  */
-export function httpTrigger<T extends PartialBy<HttpTriggerBinding<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): HttpTriggerBinding<T['name']> {
+export function httpTrigger<Binding extends HttpTriggerBinding<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<HttpTriggerBinding<Name>, 'type' | 'direction'>
+): HttpTriggerBinding<Name> {
   return {
     ...bindings,
     type: 'httpTrigger',

--- a/packages/core/src/bindings/binding/http.ts
+++ b/packages/core/src/bindings/binding/http.ts
@@ -36,9 +36,9 @@ import { HttpBinding } from '../interfaces';
  * @param bindings - `HttpBinding` Object
  * @returns `HttpBinding` Object Object with `{ type: 'http', direction: 'out' }`
  */
-export function http<T extends PartialBy<HttpBinding<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): HttpBinding<T['name']> {
+export function http<Binding extends HttpBinding<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<HttpBinding<Name>, 'type' | 'direction'>
+): HttpBinding<Name> {
   return {
     ...bindings,
     type: 'http',
@@ -80,10 +80,10 @@ export function http<T extends PartialBy<HttpBinding<unknown>, 'type' | 'directi
    * @param bindings - `HttpBinding` (Optional)
    * @returns `HttpBinding` Object with  `{ name: '$return', type: 'http', direction: 'out' }`
    */
-export function http_withReturn<T extends PartialBy<HttpBinding<unknown>, 'name' | 'type' | 'direction'>>(
-  bindings?: T
+
+export function http_withReturn<Binding extends HttpBinding<unknown>, Name extends Binding['name']>(
+  bindings?: PartialBy<HttpBinding<Name>, 'name' | 'type' | 'direction'>
 ): HttpBinding<'$return'> {
-  bindings = bindings ?? ({} as T);
   return {
     ...bindings,
     name: '$return' as const,

--- a/packages/core/src/bindings/binding/timer-trigger.ts
+++ b/packages/core/src/bindings/binding/timer-trigger.ts
@@ -36,9 +36,9 @@ import { TimerTriggerBinding } from '../interfaces';
  * @param bindings - `TimerTriggerBinding` Object
  * @returns `TimerTriggerBinding` Object Object with `{ type: 'timerTrigger', direction: 'in' }`
  */
-export function timerTrigger<T extends PartialBy<TimerTriggerBinding<unknown>, 'type' | 'direction'>>(
-  bindings: T
-): TimerTriggerBinding<T['name']> {
+export function timerTrigger<Binding extends TimerTriggerBinding<unknown>, Name extends Binding['name']>(
+  bindings: PartialBy<TimerTriggerBinding<Name>, 'type' | 'direction'>
+): TimerTriggerBinding<Name> {
   return {
     ...bindings,
     type: 'timerTrigger',

--- a/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
+++ b/packages/core/src/test-usecases/all-bindings/fixtures/functions/all-bindings.function.ts
@@ -10,9 +10,7 @@ const bindings = [
   binding.cosmosDBTrigger_v2({
     name: 'document_trigger_v2' as const,
     collectionName: '',
-    connection: '',
     connectionStringSetting: '',
-    containerName: '',
     databaseName: '',
   }),
   binding.cosmosDBTrigger_v4({


### PR DESCRIPTION
Before

<img width="553" alt="CleanShot 2566-02-26 at 10 33 40" src="https://user-images.githubusercontent.com/3647850/221390884-1fc5a824-6a1e-44d2-b3a8-abcdefe87ed8.png">

After

<img width="764" alt="CleanShot 2566-02-26 at 10 32 55" src="https://user-images.githubusercontent.com/3647850/221390890-70248001-4819-4515-854b-61f88aaf904c.png">

## Affected Binding Helpers
- binding.http()
- binding.http_withReturn()
- binding.timerTriggere()
- binding.cosmosDBTrigger_v2()
- binding.cosmosDBTrigger_v4()
- binding.cosmosDBTrigger()
- binding.cosmosDB_output_v2()
- binding.cosmosDB_output_v4()
- binding.cosmosDB_output()
- binding.cosmosDB_input_v2()
- binding.cosmosDB_input_v4()
- binding.cosmosDB_input()
